### PR TITLE
Modify FilestackClient to better support Android local uploads

### DIFF
--- a/src/integTest/java/com/filestack/TestBasicFunctions.java
+++ b/src/integTest/java/com/filestack/TestBasicFunctions.java
@@ -48,7 +48,7 @@ public class TestBasicFunctions {
     File file = createRandomFile(uuid, 15L * 1024 * 1024);
     files.add(file);
 
-    FileLink fileLink = client.upload(file.getPath(), "text/plain");
+    FileLink fileLink = client.upload(file.getPath(), false);
     String handle = fileLink.getHandle();
     handles.add(handle);
 
@@ -63,7 +63,7 @@ public class TestBasicFunctions {
     File file = createRandomFile(uuid);
     files.add(file);
 
-    FileLink fileLink = client.upload(file.getPath(), "text/plain");
+    FileLink fileLink = client.upload(file.getPath(), false);
     String handle = fileLink.getHandle();
     handles.add(handle);
     byte[] bytes = fileLink.getContent().bytes();
@@ -80,7 +80,7 @@ public class TestBasicFunctions {
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), "text/plain");
+    FileLink fileLink = client.upload(uploadFile.getPath(), false);
     String handle = fileLink.getHandle();
     handles.add(handle);
 
@@ -107,7 +107,7 @@ public class TestBasicFunctions {
     File overwriteFile = createRandomFile(overwriteUuid);
     files.add(overwriteFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), "text/plain");
+    FileLink fileLink = client.upload(uploadFile.getPath(), false);
     String handle = fileLink.getHandle();
     handles.add(handle);
 
@@ -126,7 +126,7 @@ public class TestBasicFunctions {
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), "text/plain");
+    FileLink fileLink = client.upload(uploadFile.getPath(), false);
 
     fileLink.delete();
 

--- a/src/integTest/java/com/filestack/TestImageTagging.java
+++ b/src/integTest/java/com/filestack/TestImageTagging.java
@@ -24,7 +24,7 @@ public class TestImageTagging {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, "image/jpeg");
+    FileLink fileLink = client.upload(origPath, true);
     handles.add(fileLink.getHandle());
 
     Map<String, Integer> tags = fileLink.imageTags();
@@ -39,7 +39,7 @@ public class TestImageTagging {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, "image/jpeg");
+    FileLink fileLink = client.upload(origPath, false);
     handles.add(fileLink.getHandle());
 
     Assert.assertTrue(fileLink.imageSfw());

--- a/src/integTest/java/com/filestack/TestTransforms.java
+++ b/src/integTest/java/com/filestack/TestTransforms.java
@@ -29,7 +29,7 @@ public class TestTransforms {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, "image/jpeg");
+    FileLink fileLink = client.upload(origPath, false);
     handles.add(fileLink.getHandle());
 
     ImageTransform transform = fileLink.imageTransform();
@@ -53,7 +53,7 @@ public class TestTransforms {
     String oggPath = loader.getResource("com/filestack/sample_music.ogg").getPath();
     File oggFile = new File(oggPath);
 
-    FileLink oggFileLink = client.upload(oggPath, "audio/ogg");
+    FileLink oggFileLink = client.upload(oggPath, false);
     handles.add(oggFileLink.getHandle());
 
     AvTransformOptions options = new AvTransformOptions.Builder()

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -117,9 +117,8 @@ public class FilestackClient {
     }
 
     if (!options.hasContentType()) {
-      options = options.newBuilder()
-          .contentType("application/octet-stream")
-          .build();
+      String contentType = guessContentType(path);
+      options = options.newBuilder().contentType(contentType).build();
     }
 
     Upload upload = new Upload(path, intelligent, options, this, fsService);
@@ -134,6 +133,10 @@ public class FilestackClient {
    */
   public ImageTransform imageTransform(String url) {
     return new ImageTransform(this, url);
+  }
+
+  protected static String guessContentType(String path) {
+    return "application/octet-stream";
   }
 
   public String getApiKey() {

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -19,29 +19,30 @@ public class FilestackClient {
   private FsService fsService;
 
   /**
-   * Constructs an instance without security.
+   * Constructs a client without security.
    *
-   * @see #FilestackClient(String, Security)
+   * @param apiKey account key from the dev portal
    */
   public FilestackClient(String apiKey) {
     this(apiKey, null);
   }
 
   /**
-   * Constructs an instance with security.
+   * Constructs a client with security.
    *
    * @param apiKey   account key from the dev portal
-   * @param security needs required permissions for your intended actions
+   * @param security configured security object
    */
   public FilestackClient(String apiKey, Security security) {
     this(apiKey, security, null);
   }
 
   /**
-   * Constructs an instance with security and custom {@link FsService}.
+   * Constructs a client using custom {@link FsService}. For internal use.
    *
-   * @param apiKey   account key from the dev portal
-   * @param security needs required permissions for your intended actions
+   * @param apiKey    account key from the dev portal
+   * @param security  configured security object
+   * @param fsService service to use for API calls, overrides default singleton
    */
   public FilestackClient(String apiKey, Security security, FsService fsService) {
     this.apiKey = apiKey;
@@ -96,6 +97,7 @@ public class FilestackClient {
    * Asynchronously uploads local file using default storage options.
    *
    * @see #upload(String, boolean, StorageOptions)
+   * @see #uploadAsync(String, boolean, StorageOptions)
    */
   public Flowable<Progress<FileLink>> uploadAsync(String path, boolean intelligent) {
     return uploadAsync(path, intelligent, null);

--- a/src/main/java/com/filestack/StorageOptions.java
+++ b/src/main/java/com/filestack/StorageOptions.java
@@ -43,6 +43,7 @@ public class StorageOptions {
     HashMap<String, RequestBody> map = new HashMap<>();
     addToMap(map, "store_access", access);
     addToMap(map, "store_container", container);
+    addToMap(map, "filename", filename);
     addToMap(map, "store_location", location != null ? location : "s3");
     addToMap(map, "store_path", path);
     addToMap(map, "store_region", region);

--- a/src/main/java/com/filestack/StorageOptions.java
+++ b/src/main/java/com/filestack/StorageOptions.java
@@ -4,6 +4,7 @@ import com.filestack.transforms.TransformTask;
 import com.filestack.util.Util;
 import java.util.HashMap;
 import java.util.Map;
+import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
 /** Configure storage options for uploads and transformation stores. */
@@ -15,6 +16,7 @@ public class StorageOptions {
   private String location;
   private String path;
   private String region;
+  private String contentType;
 
   public StorageOptions() { }
 
@@ -44,7 +46,20 @@ public class StorageOptions {
     addToMap(map, "store_location", location != null ? location : "s3");
     addToMap(map, "store_path", path);
     addToMap(map, "store_region", region);
+    addToMap(map, "mimetype", contentType);
     return map;
+  }
+
+  public MediaType getMediaType() {
+    return MediaType.parse(contentType);
+  }
+
+  public boolean hasContentType() {
+    return contentType != null;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
   }
 
   private static void addToMap(Map<String, RequestBody> map, String key, String value) {
@@ -61,6 +76,21 @@ public class StorageOptions {
     private String location;
     private String path;
     private String region;
+    private String contentType;
+
+    public Builder() { }
+
+    /** Create a new builder using an existing options config. */
+    public Builder(StorageOptions existing) {
+      access = existing.access;
+      base64Decode = existing.base64Decode;
+      container = existing.container;
+      filename = existing.filename;
+      location = existing.location;
+      path = existing.path;
+      region = existing.region;
+      contentType = existing.contentType;
+    }
 
     public Builder access(String access) {
       this.access = access;
@@ -97,6 +127,11 @@ public class StorageOptions {
       return this;
     }
 
+    public Builder contentType(String contentType) {
+      this.contentType = contentType;
+      return this;
+    }
+
     /**
      * Builds new {@link StorageOptions}.
      */
@@ -109,6 +144,7 @@ public class StorageOptions {
       building.location = location;
       building.path = path;
       building.region = region;
+      building.contentType = contentType;
       return building;
     }
   }

--- a/src/main/java/com/filestack/util/Upload.java
+++ b/src/main/java/com/filestack/util/Upload.java
@@ -19,9 +19,9 @@ public class Upload {
   static final int CONCURRENCY = 4;
   static final int PROG_INTERVAL = 2;
   static final int MIN_CHUNK_SIZE = 32 * 1024;
+  static final int DELAY_BASE = 2;
 
   final FsService fsService;
-  final int delayBase;
   final MediaType mediaType;
   final Security security;
   final String apiKey;
@@ -37,19 +37,17 @@ public class Upload {
   String[] etags;
 
   /** Constructs new instance. */
-  public Upload(String path, String contentType, StorageOptions options, boolean intelligent,
-                int delayBase, FilestackClient fsClient, FsService fsService) {
+  public Upload(String path, boolean intelligent, StorageOptions options,
+                FilestackClient fsClient, FsService fsService) {
 
     this.path = path;
-    mediaType = MediaType.parse(contentType);
-    this.delayBase = delayBase;
+    mediaType = options.getMediaType();
     apiKey = fsClient.getApiKey();
     security = fsClient.getSecurity();
     this.fsService = fsService;
 
     // Setup base parameters
     baseParams = new HashMap<>();
-    baseParams.put("mimetype", Util.createStringPart(contentType));
     baseParams.putAll(options.getAsPartMap());
 
     if (intelligent) {

--- a/src/main/java/com/filestack/util/UploadCompleteFunc.java
+++ b/src/main/java/com/filestack/util/UploadCompleteFunc.java
@@ -39,7 +39,7 @@ public class UploadCompleteFunc implements Callable<Prog<FileLink>> {
     }
 
     RetryNetworkFunc<CompleteResponse> func;
-    func = new RetryNetworkFunc<CompleteResponse>(5, 5, upload.delayBase) {
+    func = new RetryNetworkFunc<CompleteResponse>(5, 5, Upload.DELAY_BASE) {
 
       @Override
       Response<CompleteResponse> work() throws Exception {

--- a/src/main/java/com/filestack/util/UploadStartFunc.java
+++ b/src/main/java/com/filestack/util/UploadStartFunc.java
@@ -25,7 +25,9 @@ public class UploadStartFunc implements Callable<Prog<FileLink>> {
     File file = Util.createReadFile(upload.path);
     upload.filesize = file.length();
 
-    upload.baseParams.put("filename", Util.createStringPart(file.getName()));
+    if (!upload.baseParams.containsKey("filename")) {
+      upload.baseParams.put("filename", Util.createStringPart(file.getName()));
+    }
     upload.baseParams.put("size", Util.createStringPart(Long.toString(upload.filesize)));
 
     RetryNetworkFunc<StartResponse> func;

--- a/src/main/java/com/filestack/util/UploadStartFunc.java
+++ b/src/main/java/com/filestack/util/UploadStartFunc.java
@@ -29,7 +29,7 @@ public class UploadStartFunc implements Callable<Prog<FileLink>> {
     upload.baseParams.put("size", Util.createStringPart(Long.toString(upload.filesize)));
 
     RetryNetworkFunc<StartResponse> func;
-    func = new RetryNetworkFunc<StartResponse>(0, 5, upload.delayBase) {
+    func = new RetryNetworkFunc<StartResponse>(0, 5, Upload.DELAY_BASE) {
       @Override
       Response<StartResponse> work() throws Exception {
         return upload.fsService.start(upload.baseParams).execute();

--- a/src/main/java/com/filestack/util/UploadTransferFunc.java
+++ b/src/main/java/com/filestack/util/UploadTransferFunc.java
@@ -124,7 +124,7 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
     }
 
     RetryNetworkFunc<UploadResponse> func;
-    func = new RetryNetworkFunc<UploadResponse>(5, 5, upload.delayBase) {
+    func = new RetryNetworkFunc<UploadResponse>(5, 5, Upload.DELAY_BASE) {
       @Override
       Response<UploadResponse> work() throws Exception {
         return upload.fsService.upload(params).execute();
@@ -140,7 +140,7 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
       throws Exception {
 
     RetryNetworkFunc<Integer> func;
-    func = new RetryNetworkFunc<Integer>(5, 5, upload.delayBase) {
+    func = new RetryNetworkFunc<Integer>(5, 5, Upload.DELAY_BASE) {
       private int attemptSize = size;
 
       @Override
@@ -181,7 +181,7 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
     params.put("part", Util.createStringPart(Integer.toString(part)));
 
     RetryNetworkFunc<ResponseBody> func;
-    func = new RetryNetworkFunc<ResponseBody>(5, 5, upload.delayBase) {
+    func = new RetryNetworkFunc<ResponseBody>(5, 5, Upload.DELAY_BASE) {
       @Override
       Response<ResponseBody> work() throws Exception {
         return upload.fsService.commit(params).execute();

--- a/src/test/java/com/filestack/TestFilestackClient.java
+++ b/src/test/java/com/filestack/TestFilestackClient.java
@@ -153,7 +153,7 @@ public class TestFilestackClient {
 
     FilestackClient client = new FilestackClient("apiKey", security);
     thrown.expect(ValidationException.class);
-    client.upload("/does_not_exist.txt", "text/plain");
+    client.upload("/does_not_exist.txt", true);
   }
 
   @Test
@@ -169,16 +169,11 @@ public class TestFilestackClient {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "app_secret");
 
-    FilestackClient client = new FilestackClient.Builder()
-        .apiKey("api_key")
-        .security(security)
-        .service(mockFsService)
-        .delayBase(0)
-        .build();
+    FilestackClient client = new FilestackClient("apiKey", security, mockFsService);
 
     Path path = createRandomFile(10 * 1024 * 1024);
 
-    FileLink fileLink = client.upload(path.toString(), "text/plain");
+    FileLink fileLink = client.upload(path.toString(), false);
 
     Assert.assertEquals("handle", fileLink.getHandle());
 

--- a/src/test/java/com/filestack/transforms/TestImageTransform.java
+++ b/src/test/java/com/filestack/transforms/TestImageTransform.java
@@ -66,10 +66,7 @@ public class TestImageTransform {
   public void testDebugExternal() throws Exception {
     String url = "https://example.com/image.jpg";
     FsService mockFsService = Mockito.mock(FsService.class);
-    FilestackClient client = new FilestackClient.Builder()
-        .apiKey("apiKey")
-        .service(mockFsService)
-        .build();
+    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
 
     Mockito.doReturn(Calls.response(new JsonObject()))
         .when(mockFsService)
@@ -103,10 +100,7 @@ public class TestImageTransform {
   public void testStoreExternal() throws Exception {
     FsService mockFsService = Mockito.mock(FsService.class);
 
-    FilestackClient client = new FilestackClient.Builder()
-        .apiKey("apiKey")
-        .service(mockFsService)
-        .build();
+    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
 
     String jsonString = "{'url': 'https://cdn.filestackcontent.com/handle'}";
     Gson gson = new Gson();

--- a/src/test/java/com/filestack/transforms/TestTransform.java
+++ b/src/test/java/com/filestack/transforms/TestTransform.java
@@ -100,10 +100,7 @@ public class TestTransform {
         .when(mockFsService)
         .transformExt("apiKey", "task", "https://example.com/");
 
-    FilestackClient client = new FilestackClient.Builder()
-        .apiKey("apiKey")
-        .service(mockFsService)
-        .build();
+    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
 
     Transform transform = new Transform(client, "https://example.com/");
     transform.tasks.add(new TransformTask("task"));


### PR DESCRIPTION
https://filestack.atlassian.net/browse/FS-1807

- This was needed to make adding Android URI uploads cleaner
- Reduced number of upload method overloads in FilestackClient
- Changed args to upload methods, new ordering, intelligent option now required
- Fixed custom storage filename not getting passed