### PR TITLE
Refactor for Android SDK cloud integrations

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -178,11 +178,11 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-        </module>
+        <!--<module name="CustomImportOrder">-->
+            <!--<property name="sortImportsInGroupAlphabetically" value="true"/>-->
+            <!--<property name="separateLineBetweenGroups" value="true"/>-->
+            <!--<property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>-->
+        <!--</module>-->
         <module name="MethodParamPad"/>
         <module name="ParenPad"/>
         <module name="OperatorWrap">

--- a/src/integTest/java/com/filestack/TestBasicFunctions.java
+++ b/src/integTest/java/com/filestack/TestBasicFunctions.java
@@ -41,13 +41,13 @@ public class TestBasicFunctions {
 
   @Test
   public void testUpload() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     String uuid = UUID.randomUUID().toString();
     File file = createRandomFile(uuid, 15L * 1024 * 1024);
     files.add(file);
 
-    FsFile fsFile = client.upload(file.getPath(), false);
+    FsFile fsFile = fsClient.upload(file.getPath(), false);
     String handle = fsFile.getHandle();
     handles.add(handle);
 
@@ -56,13 +56,13 @@ public class TestBasicFunctions {
 
   @Test
   public void testGetContent() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     String uuid = UUID.randomUUID().toString();
     File file = createRandomFile(uuid);
     files.add(file);
 
-    FsFile fsFile = client.upload(file.getPath(), false);
+    FsFile fsFile = fsClient.upload(file.getPath(), false);
     String handle = fsFile.getHandle();
     handles.add(handle);
     byte[] bytes = fsFile.getContent().bytes();
@@ -73,13 +73,13 @@ public class TestBasicFunctions {
 
   @Test
   public void testDownload() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FsFile fsFile = client.upload(uploadFile.getPath(), false);
+    FsFile fsFile = fsClient.upload(uploadFile.getPath(), false);
     String handle = fsFile.getHandle();
     handles.add(handle);
 
@@ -96,7 +96,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testOverwrite() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);
@@ -106,7 +106,7 @@ public class TestBasicFunctions {
     File overwriteFile = createRandomFile(overwriteUuid);
     files.add(overwriteFile);
 
-    FsFile fsFile = client.upload(uploadFile.getPath(), false);
+    FsFile fsFile = fsClient.upload(uploadFile.getPath(), false);
     String handle = fsFile.getHandle();
     handles.add(handle);
 
@@ -119,13 +119,13 @@ public class TestBasicFunctions {
 
   @Test
   public void testDelete() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FsFile fsFile = client.upload(uploadFile.getPath(), false);
+    FsFile fsFile = fsClient.upload(uploadFile.getPath(), false);
 
     fsFile.delete();
 
@@ -136,8 +136,10 @@ public class TestBasicFunctions {
   /** Deletes any files uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
+
     for (String handle : handles) {
-      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(fsClient, handle);
       try {
         fsFile.delete();
       } catch (Exception e) {

--- a/src/integTest/java/com/filestack/TestBasicFunctions.java
+++ b/src/integTest/java/com/filestack/TestBasicFunctions.java
@@ -47,8 +47,8 @@ public class TestBasicFunctions {
     File file = createRandomFile(uuid, 15L * 1024 * 1024);
     files.add(file);
 
-    FileLink fileLink = client.upload(file.getPath(), false);
-    String handle = fileLink.getHandle();
+    FsFile fsFile = client.upload(file.getPath(), false);
+    String handle = fsFile.getHandle();
     handles.add(handle);
 
     Assert.assertNotNull(handle);
@@ -62,10 +62,10 @@ public class TestBasicFunctions {
     File file = createRandomFile(uuid);
     files.add(file);
 
-    FileLink fileLink = client.upload(file.getPath(), false);
-    String handle = fileLink.getHandle();
+    FsFile fsFile = client.upload(file.getPath(), false);
+    String handle = fsFile.getHandle();
     handles.add(handle);
-    byte[] bytes = fileLink.getContent().bytes();
+    byte[] bytes = fsFile.getContent().bytes();
     String content = new String(bytes, "utf-16");
 
     Assert.assertEquals(uuid, content);
@@ -79,14 +79,14 @@ public class TestBasicFunctions {
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), false);
-    String handle = fileLink.getHandle();
+    FsFile fsFile = client.upload(uploadFile.getPath(), false);
+    String handle = fsFile.getHandle();
     handles.add(handle);
 
     String downloadUuid = UUID.randomUUID().toString();
     File downloadFile = new File("/tmp/" + downloadUuid + ".txt");
     files.add(downloadFile);
-    fileLink.download("/tmp/", downloadFile.getName());
+    fsFile.download("/tmp/", downloadFile.getName());
 
     Assert.assertTrue(downloadFile.isFile());
     byte[] bytes = Files.asByteSource(downloadFile).read();
@@ -106,13 +106,13 @@ public class TestBasicFunctions {
     File overwriteFile = createRandomFile(overwriteUuid);
     files.add(overwriteFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), false);
-    String handle = fileLink.getHandle();
+    FsFile fsFile = client.upload(uploadFile.getPath(), false);
+    String handle = fsFile.getHandle();
     handles.add(handle);
 
-    fileLink.overwrite(overwriteFile.getPath());
+    fsFile.overwrite(overwriteFile.getPath());
 
-    byte[] bytes = fileLink.getContent().bytes();
+    byte[] bytes = fsFile.getContent().bytes();
     String content = new String(bytes, "utf-16");
     Assert.assertEquals(overwriteUuid, content);
   }
@@ -125,23 +125,23 @@ public class TestBasicFunctions {
     File uploadFile = createRandomFile(uploadUuid);
     files.add(uploadFile);
 
-    FileLink fileLink = client.upload(uploadFile.getPath(), false);
+    FsFile fsFile = client.upload(uploadFile.getPath(), false);
 
-    fileLink.delete();
+    fsFile.delete();
 
     thrown.expect(HttpResponseException.class);
-    fileLink.getContent();
+    fsFile.getContent();
   }
 
   /** Deletes any files uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
     for (String handle : handles) {
-      FileLink fileLink = new FileLink(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
       try {
-        fileLink.delete();
+        fsFile.delete();
       } catch (Exception e) {
-        Assert.fail("FileLink delete failed");
+        Assert.fail("FsFile delete failed");
       }
     }
   }

--- a/src/integTest/java/com/filestack/TestBasicFunctions.java
+++ b/src/integTest/java/com/filestack/TestBasicFunctions.java
@@ -41,7 +41,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testUpload() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     String uuid = UUID.randomUUID().toString();
     File file = createRandomFile(uuid, 15L * 1024 * 1024);
@@ -56,7 +56,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testGetContent() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     String uuid = UUID.randomUUID().toString();
     File file = createRandomFile(uuid);
@@ -73,7 +73,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testDownload() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);
@@ -96,7 +96,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testOverwrite() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);
@@ -119,7 +119,7 @@ public class TestBasicFunctions {
 
   @Test
   public void testDelete() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     String uploadUuid = UUID.randomUUID().toString();
     File uploadFile = createRandomFile(uploadUuid);

--- a/src/integTest/java/com/filestack/TestBasicFunctions.java
+++ b/src/integTest/java/com/filestack/TestBasicFunctions.java
@@ -129,7 +129,7 @@ public class TestBasicFunctions {
 
     fsFile.delete();
 
-    thrown.expect(HttpResponseException.class);
+    thrown.expect(HttpException.class);
     fsFile.getContent();
   }
 

--- a/src/integTest/java/com/filestack/TestImageTagging.java
+++ b/src/integTest/java/com/filestack/TestImageTagging.java
@@ -18,7 +18,7 @@ public class TestImageTagging {
 
   @Test
   public void testImageTags() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
@@ -33,7 +33,7 @@ public class TestImageTagging {
 
   @Test
   public void testImageSfw() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();

--- a/src/integTest/java/com/filestack/TestImageTagging.java
+++ b/src/integTest/java/com/filestack/TestImageTagging.java
@@ -18,13 +18,13 @@ public class TestImageTagging {
 
   @Test
   public void testImageTags() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FsFile fsFile = client.upload(origPath, true);
+    FsFile fsFile = fsClient.upload(origPath, true);
     handles.add(fsFile.getHandle());
 
     Map<String, Integer> tags = fsFile.imageTags();
@@ -33,13 +33,13 @@ public class TestImageTagging {
 
   @Test
   public void testImageSfw() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FsFile fsFile = client.upload(origPath, false);
+    FsFile fsFile = fsClient.upload(origPath, false);
     handles.add(fsFile.getHandle());
 
     Assert.assertTrue(fsFile.imageSfw());
@@ -48,8 +48,10 @@ public class TestImageTagging {
   /** Deletes any files uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
+    
     for (String handle : handles) {
-      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(fsClient, handle);
       try {
         fsFile.delete();
       } catch (Exception e) {

--- a/src/integTest/java/com/filestack/TestImageTagging.java
+++ b/src/integTest/java/com/filestack/TestImageTagging.java
@@ -24,10 +24,10 @@ public class TestImageTagging {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, true);
-    handles.add(fileLink.getHandle());
+    FsFile fsFile = client.upload(origPath, true);
+    handles.add(fsFile.getHandle());
 
-    Map<String, Integer> tags = fileLink.imageTags();
+    Map<String, Integer> tags = fsFile.imageTags();
     Assert.assertNotNull(tags.get("nebula"));
   }
 
@@ -39,21 +39,21 @@ public class TestImageTagging {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, false);
-    handles.add(fileLink.getHandle());
+    FsFile fsFile = client.upload(origPath, false);
+    handles.add(fsFile.getHandle());
 
-    Assert.assertTrue(fileLink.imageSfw());
+    Assert.assertTrue(fsFile.imageSfw());
   }
 
   /** Deletes any files uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
     for (String handle : handles) {
-      FileLink fileLink = new FileLink(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
       try {
-        fileLink.delete();
+        fsFile.delete();
       } catch (Exception e) {
-        Assert.fail("FileLink delete failed");
+        Assert.fail("FsFile delete failed");
       }
     }
   }

--- a/src/integTest/java/com/filestack/TestTransforms.java
+++ b/src/integTest/java/com/filestack/TestTransforms.java
@@ -29,10 +29,10 @@ public class TestTransforms {
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FileLink fileLink = client.upload(origPath, false);
-    handles.add(fileLink.getHandle());
+    FsFile fsFile = client.upload(origPath, false);
+    handles.add(fsFile.getHandle());
 
-    ImageTransform transform = fileLink.imageTransform();
+    ImageTransform transform = fsFile.imageTransform();
     transform.addTask(new CropTask(0, 0, 500, 500));
 
     String cropPath = loader.getResource("com/filestack/sample_image_cropped.jpg").getPath();
@@ -53,26 +53,26 @@ public class TestTransforms {
     String oggPath = loader.getResource("com/filestack/sample_music.ogg").getPath();
     File oggFile = new File(oggPath);
 
-    FileLink oggFileLink = client.upload(oggPath, false);
-    handles.add(oggFileLink.getHandle());
+    FsFile oggFsFile = client.upload(oggPath, false);
+    handles.add(oggFsFile.getHandle());
 
     AvTransformOptions options = new AvTransformOptions.Builder()
         .preset("mp3")
         .build();
 
-    AvTransform transform = oggFileLink.avTransform(options);
+    AvTransform transform = oggFsFile.avTransform(options);
 
-    FileLink mp3FileLink;
-    while ((mp3FileLink = transform.getFileLink()) == null) {
+    FsFile mp3FsFile;
+    while ((mp3FsFile = transform.getFileLink()) == null) {
       Thread.sleep(5 * 1000);
     }
-    handles.add(mp3FileLink.getHandle());
+    handles.add(mp3FsFile.getHandle());
 
     String mp3Path = loader.getResource("com/filestack/sample_music.mp3").getPath();
     File mp3File = new File(mp3Path);
 
     String correct = Files.asByteSource(mp3File).hash(Hashing.sha256()).toString();
-    byte[] bytes = mp3FileLink.getContent().bytes();
+    byte[] bytes = mp3FsFile.getContent().bytes();
     String output = Hashing.sha256().hashBytes(bytes).toString();
 
     Assert.assertEquals(correct, output);
@@ -82,11 +82,11 @@ public class TestTransforms {
   @AfterClass
   public static void cleanupHandles() {
     for (String handle : handles) {
-      FileLink fileLink = new FileLink(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
       try {
-        fileLink.delete();
+        fsFile.delete();
       } catch (Exception e) {
-        Assert.fail("FileLink delete failed");
+        Assert.fail("FsFile delete failed");
       }
     }
   }

--- a/src/integTest/java/com/filestack/TestTransforms.java
+++ b/src/integTest/java/com/filestack/TestTransforms.java
@@ -23,7 +23,7 @@ public class TestTransforms {
 
   @Test
   public void testImageTransform() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
@@ -47,7 +47,7 @@ public class TestTransforms {
 
   @Test
   public void testAvTransform() throws Exception {
-    FilestackClient client = new FilestackClient(API_KEY, SECURITY);
+    FsClient client = new FsClient(API_KEY, SECURITY);
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String oggPath = loader.getResource("com/filestack/sample_music.ogg").getPath();

--- a/src/integTest/java/com/filestack/TestTransforms.java
+++ b/src/integTest/java/com/filestack/TestTransforms.java
@@ -23,13 +23,13 @@ public class TestTransforms {
 
   @Test
   public void testImageTransform() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String origPath = loader.getResource("com/filestack/sample_image.jpg").getPath();
     File origFile = new File(origPath);
 
-    FsFile fsFile = client.upload(origPath, false);
+    FsFile fsFile = fsClient.upload(origPath, false);
     handles.add(fsFile.getHandle());
 
     ImageTransform transform = fsFile.imageTransform();
@@ -47,13 +47,13 @@ public class TestTransforms {
 
   @Test
   public void testAvTransform() throws Exception {
-    FsClient client = new FsClient(API_KEY, SECURITY);
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
 
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String oggPath = loader.getResource("com/filestack/sample_music.ogg").getPath();
     File oggFile = new File(oggPath);
 
-    FsFile oggFsFile = client.upload(oggPath, false);
+    FsFile oggFsFile = fsClient.upload(oggPath, false);
     handles.add(oggFsFile.getHandle());
 
     AvTransformOptions options = new AvTransformOptions.Builder()
@@ -81,8 +81,10 @@ public class TestTransforms {
   /** Deletes any files uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
+    FsClient fsClient = new FsClient.Builder().apiKey(API_KEY).security(SECURITY).build();
+
     for (String handle : handles) {
-      FsFile fsFile = new FsFile(API_KEY, handle, SECURITY);
+      FsFile fsFile = new FsFile(fsClient, handle);
       try {
         fsFile.delete();
       } catch (Exception e) {

--- a/src/main/java/com/filestack/AppInfo.java
+++ b/src/main/java/com/filestack/AppInfo.java
@@ -2,7 +2,7 @@ package com.filestack;
 
 import com.google.gson.annotations.SerializedName;
 
-public class AccountInfo {
+public class AppInfo {
   @SerializedName("intelligent_ingestion") private boolean intelligent;
   private boolean blocked;
   @SerializedName("whitelabel") private boolean whiteLabel;

--- a/src/main/java/com/filestack/CloudContents.java
+++ b/src/main/java/com/filestack/CloudContents.java
@@ -27,6 +27,10 @@ public class CloudContents {
   }
 
   public String getNextToken() {
+    // An empty string token is confusing, just return null
+    if (next == null || next.equals("")) {
+      return null;
+    }
     return next;
   }
 }

--- a/src/main/java/com/filestack/CloudItem.java
+++ b/src/main/java/com/filestack/CloudItem.java
@@ -9,6 +9,21 @@ public class CloudItem {
   private long bytes;
   private boolean folder;
 
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+
+    if (!(obj instanceof CloudItem)) {
+      return false;
+    }
+
+    CloudItem item = (CloudItem) obj;
+
+    return this.getPath().equals(item.getPath());
+  }
+
   public String getName() {
     return name;
   }

--- a/src/main/java/com/filestack/CloudResponse.java
+++ b/src/main/java/com/filestack/CloudResponse.java
@@ -2,9 +2,9 @@ package com.filestack;
 
 import com.filestack.util.responses.CloudAuthHolder;
 
-public class CloudContents {
+public class CloudResponse {
   private CloudAuthHolder auth;
-  private CloudItem[] contents;
+  private CloudItem[] items;
   private String client;
   private String filename;
   private String next;
@@ -15,7 +15,7 @@ public class CloudContents {
   }
 
   public CloudItem[] getItems() {
-    return contents;
+    return items;
   }
 
   public String getProvider() {
@@ -26,6 +26,7 @@ public class CloudContents {
     return filename;
   }
 
+  /** Returns a pagination token if all items can't be returned at once. */
   public String getNextToken() {
     // An empty string token is confusing, just return null
     if (next == null || next.equals("")) {

--- a/src/main/java/com/filestack/CloudResponse.java
+++ b/src/main/java/com/filestack/CloudResponse.java
@@ -1,13 +1,18 @@
 package com.filestack;
 
 import com.filestack.util.responses.CloudAuthHolder;
+import com.google.gson.annotations.SerializedName;
 
 public class CloudResponse {
   private CloudAuthHolder auth;
+  @SerializedName("contents")
   private CloudItem[] items;
-  private String client;
-  private String filename;
-  private String next;
+  @SerializedName("client")
+  private String provider;
+  @SerializedName("filename")
+  private String directory;
+  @SerializedName("next")
+  private String nextToken;
 
   /** Returns an OAuth URL or null if the user has already authorized. */
   public String getAuthUrl() {
@@ -19,19 +24,19 @@ public class CloudResponse {
   }
 
   public String getProvider() {
-    return client;
+    return provider;
   }
 
   public String getDirectory() {
-    return filename;
+    return directory;
   }
 
   /** Returns a pagination token if all items can't be returned at once. */
   public String getNextToken() {
     // An empty string token is confusing, just return null
-    if (next == null || next.equals("")) {
+    if (nextToken == null || nextToken.equals("")) {
       return null;
     }
-    return next;
+    return nextToken;
   }
 }

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -103,10 +103,10 @@ public class FilestackClient {
   /**
    * Gets contents of a user's cloud "drive".
    *
-   * @see #getCloudContents(String, String, String)
+   * @see #getCloudItems(String, String, String)
    */
-  public CloudContents getCloudContents(String providerName, String path) throws IOException {
-    return getCloudContents(providerName, path, null);
+  public CloudResponse getCloudItems(String providerName, String path) throws IOException {
+    return getCloudItems(providerName, path, null);
   }
 
   /**
@@ -119,7 +119,7 @@ public class FilestackClient {
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public CloudContents getCloudContents(String providerName, String path, String next)
+  public CloudResponse getCloudItems(String providerName, String path, String next)
       throws IOException {
 
     JsonObject params = makeCloudParams(providerName, path, next);
@@ -133,7 +133,7 @@ public class FilestackClient {
 
     JsonElement provider = base.get(providerName);
     Gson gson = new Gson();
-    return gson.fromJson(provider, CloudContents.class);
+    return gson.fromJson(provider, CloudResponse.class);
   }
 
   /**
@@ -239,24 +239,24 @@ public class FilestackClient {
   /**
    * Asynchronously gets contents of a user's cloud "drive".
    *
-   * @see #getCloudContents(String, String, String)
+   * @see #getCloudItems(String, String, String)
    */
-  public Single<CloudContents> getCloudContentsAsync(String providerName, String path) {
-    return getCloudContentsAsync(providerName, path, null);
+  public Single<CloudResponse> getCloudItemsAsync(String providerName, String path) {
+    return getCloudItemsAsync(providerName, path, null);
   }
 
   /**
    * Asynchronously gets contents of a user's cloud "drive".
    *
-   * @see #getCloudContents(String, String, String)
+   * @see #getCloudItems(String, String, String)
    */
-  public Single<CloudContents> getCloudContentsAsync(final String providerName, final String path,
+  public Single<CloudResponse> getCloudItemsAsync(final String providerName, final String path,
                                                      final String next) {
 
-    return Single.fromCallable(new Callable<CloudContents>() {
+    return Single.fromCallable(new Callable<CloudResponse>() {
       @Override
-      public CloudContents call() throws Exception {
-        return getCloudContents(providerName, path, next);
+      public CloudResponse call() throws Exception {
+        return getCloudItems(providerName, path, next);
       }
     })
         .subscribeOn(Schedulers.io())

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -93,9 +93,9 @@ public class FilestackClient {
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public AccountInfo getAccountInfo() throws IOException {
+  public AppInfo getAppInfo() throws IOException {
     JsonObject params = makeCloudParams();
-    Response<AccountInfo> response = fsService.cloud().prefetch(params).execute();
+    Response<AppInfo> response = fsService.cloud().prefetch(params).execute();
     Util.checkResponseAndThrow(response);
     return response.body();
   }
@@ -223,13 +223,13 @@ public class FilestackClient {
   /**
    * Asynchronously get basic account info for this client's API key.
    *
-   * @see #getAccountInfo()
+   * @see #getAppInfo()
    */
-  public Single<AccountInfo> getAccountInfoAsync() {
-    return Single.fromCallable(new Callable<AccountInfo>() {
+  public Single<AppInfo> getAppInfoAsync() {
+    return Single.fromCallable(new Callable<AppInfo>() {
       @Override
-      public AccountInfo call() throws Exception {
-        return getAccountInfo();
+      public AppInfo call() throws Exception {
+        return getAppInfo();
       }
     })
         .subscribeOn(Schedulers.io())

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -19,22 +19,6 @@ import retrofit2.Response;
 
 /** Uploads new files. */
 public class FilestackClient {
-  // public static final String CLOUD_IMAGE_SEARCH = "imagesearch";
-  public static final String CLOUD_FACEBOOK = "facebook";
-  public static final String CLOUD_INSTAGRAM = "instagram";
-  public static final String CLOUD_GOOGLE_DRIVE = "googledrive";
-  public static final String CLOUD_DROPBOX = "dropbox";
-  public static final String CLOUD_EVERNOTE = "evernote";
-  public static final String CLOUD_FLICKR = "flickr";
-  public static final String CLOUD_BOX = "box";
-  public static final String CLOUD_GITHUB = "github";
-  public static final String CLOUD_GMAIL = "gmail";
-  public static final String CLOUD_GOOGLE_PHOTOS = "picasa";
-  public static final String CLOUD_ONEDRIVE = "onedrive";
-  public static final String CLOUD_AMAZON_DRIVE = "clouddrive";
-  // public static final String CLOUD_CUSTOM_SOURCE = "customsource";
-  // public static final String CLOUD_VIDEO = "video";
-
   private String apiKey;
   private Security security;
   private FsService fsService;

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -62,7 +62,7 @@ public class FilestackClient {
    *
    * @see #upload(String, boolean, StorageOptions)
    */
-  public FileLink upload(String path, boolean intelligent) throws IOException {
+  public FsFile upload(String path, boolean intelligent) throws IOException {
     return upload(path, intelligent, null);
   }
 
@@ -73,11 +73,11 @@ public class FilestackClient {
    * @param options     storage options, https://www.filestack.com/docs/rest-api/store
    * @param intelligent intelligent ingestion, setting to true to will decrease failures in very
    *                    poor network conditions at the expense of upload speed
-   * @return new {@link FileLink} referencing file
+   * @return new {@link FsFile} referencing file
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on error reading file or network failure
    */
-  public FileLink upload(String path, boolean intelligent, StorageOptions options)
+  public FsFile upload(String path, boolean intelligent, StorageOptions options)
       throws IOException {
 
     try {
@@ -141,7 +141,7 @@ public class FilestackClient {
    *
    * @see #storeCloudItem(String, String, StorageOptions)
    */
-  public FileLink storeCloudItem(String providerName, String path) throws IOException {
+  public FsFile storeCloudItem(String providerName, String path) throws IOException {
     return storeCloudItem(providerName, path, null);
   }
 
@@ -154,7 +154,7 @@ public class FilestackClient {
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public FileLink storeCloudItem(String providerName, String path, StorageOptions options)
+  public FsFile storeCloudItem(String providerName, String path, StorageOptions options)
       throws IOException {
 
     if (options == null) {
@@ -168,7 +168,7 @@ public class FilestackClient {
     JsonElement responseJson = response.body().get(providerName);
     Gson gson = new Gson();
     CloudStoreResponse storeInfo = gson.fromJson(responseJson, CloudStoreResponse.class);
-    return new FileLink(apiKey, storeInfo.getHandle(), security);
+    return new FsFile(apiKey, storeInfo.getHandle(), security);
   }
 
   /**
@@ -192,20 +192,20 @@ public class FilestackClient {
    * @see #upload(String, boolean, StorageOptions)
    * @see #uploadAsync(String, boolean, StorageOptions)
    */
-  public Flowable<Progress<FileLink>> uploadAsync(String path, boolean intelligent) {
+  public Flowable<Progress<FsFile>> uploadAsync(String path, boolean intelligent) {
     return uploadAsync(path, intelligent, null);
   }
 
   /**
    * Asynchronously uploads local file. A stream of {@link Progress} objects are emitted by the
    * returned {@link Flowable}. The final {@link Progress} object will return a new
-   * {@link FileLink} from {@link Progress#getData()}. The upload is not done until
+   * {@link FsFile} from {@link Progress#getData()}. The upload is not done until
    * {@link Progress#getData()} returns non-null.
    *
    * @see #upload(String, boolean, StorageOptions)
    */
-  public Flowable<Progress<FileLink>> uploadAsync(String path, boolean intelligent,
-                                                  StorageOptions options) {
+  public Flowable<Progress<FsFile>> uploadAsync(String path, boolean intelligent,
+                                                StorageOptions options) {
 
     if (options == null) {
       options = new StorageOptions();
@@ -269,7 +269,7 @@ public class FilestackClient {
    *
    * @see #storeCloudItem(String, String, StorageOptions)
    */
-  public Single<FileLink> storeCloudItemAsync(final String providerName, final String path) {
+  public Single<FsFile> storeCloudItemAsync(final String providerName, final String path) {
     return storeCloudItemAsync(providerName, path, null);
   }
 
@@ -278,12 +278,12 @@ public class FilestackClient {
    *
    * @see #storeCloudItem(String, String, StorageOptions)
    */
-  public Single<FileLink> storeCloudItemAsync(final String providerName, final String path,
-                                              final StorageOptions options) {
+  public Single<FsFile> storeCloudItemAsync(final String providerName, final String path,
+                                            final StorageOptions options) {
 
-    return Single.fromCallable(new Callable<FileLink>() {
+    return Single.fromCallable(new Callable<FsFile>() {
       @Override
-      public FileLink call() throws Exception {
+      public FsFile call() throws Exception {
         return storeCloudItem(providerName, path, options);
       }
     })

--- a/src/main/java/com/filestack/FilestackClient.java
+++ b/src/main/java/com/filestack/FilestackClient.java
@@ -361,4 +361,12 @@ public class FilestackClient {
   public void setReturnUrl(String returnUrl) {
     this.returnUrl = returnUrl;
   }
+
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  public void setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
+  }
 }

--- a/src/main/java/com/filestack/FsClient.java
+++ b/src/main/java/com/filestack/FsClient.java
@@ -32,62 +32,65 @@ public class FsClient {
   /**
    * Builds new {@link FsFile}.
    */
-  public static class Builder {
-    private FsService fsService;
-    private Scheduler subScheduler;
-    private Scheduler obsScheduler;
-    private Security security;
-    private String apiKey;
-    private String sessionToken;
-    private String returnUrl;
+  @SuppressWarnings("unchecked")
+  public static class Builder<T extends Builder<T>> {
+    protected FsService fsService;
+    protected Scheduler subScheduler;
+    protected Scheduler obsScheduler;
+    protected Security security;
+    protected String apiKey;
+    protected String sessionToken;
+    protected String returnUrl;
 
-    public Builder fsService(FsService fsService) {
+    public T fsService(FsService fsService) {
       this.fsService = fsService;
-      return this;
+      return (T) this;
     }
 
-    public Builder subScheduler(Scheduler subScheduler) {
+    public T subScheduler(Scheduler subScheduler) {
       this.subScheduler = subScheduler;
-      return this;
+      return (T) this;
     }
 
-    public Builder obsScheduler(Scheduler obsScheduler) {
+    public T obsScheduler(Scheduler obsScheduler) {
       this.obsScheduler = obsScheduler;
-      return this;
+      return (T) this;
     }
 
-    public Builder security(Security security) {
+    public T security(Security security) {
       this.security = security;
-      return this;
+      return (T) this;
     }
 
-    public Builder apiKey(String apiKey) {
+    public T apiKey(String apiKey) {
       this.apiKey = apiKey;
-      return this;
+      return (T) this;
     }
 
-    public Builder sessionToken(String sessionToken) {
+    public T sessionToken(String sessionToken) {
       this.sessionToken = sessionToken;
-      return this;
+      return (T) this;
     }
 
-    public Builder returnUrl(String returnUrl) {
+    public T returnUrl(String returnUrl) {
       this.returnUrl = returnUrl;
-      return this;
+      return (T) this;
     }
 
     /**
      * Create the {@link FsFile} using the configured values.
      */
     public FsClient build() {
+      subScheduler = subScheduler != null ? subScheduler : Schedulers.io();
+      obsScheduler = obsScheduler != null ? obsScheduler : Schedulers.single();
       return new FsClient(this);
     }
   }
 
-  protected FsClient(Builder builder) {
+  protected FsClient(Builder<?> builder) {
     fsService = builder.fsService != null ? builder.fsService : new FsService();
-    subScheduler = builder.subScheduler != null ? builder.subScheduler : Schedulers.io();
-    obsScheduler = builder.obsScheduler != null ? builder.obsScheduler : Schedulers.single();
+    subScheduler = builder.subScheduler;
+    obsScheduler = builder.obsScheduler;
     security = builder.security;
     apiKey = builder.apiKey;
     sessionToken = builder.sessionToken;

--- a/src/main/java/com/filestack/FsClient.java
+++ b/src/main/java/com/filestack/FsClient.java
@@ -30,7 +30,7 @@ public class FsClient {
   private String sessionToken;
 
   /**
-   * Builds new {@link FsFile}.
+   * Builds new {@link FsClient}.
    */
   @SuppressWarnings("unchecked")
   public static class Builder<T extends Builder<T>> {
@@ -78,7 +78,7 @@ public class FsClient {
     }
 
     /**
-     * Create the {@link FsFile} using the configured values.
+     * Create the {@link FsClient} using the configured values.
      */
     public FsClient build() {
       subScheduler = subScheduler != null ? subScheduler : Schedulers.io();

--- a/src/main/java/com/filestack/FsClient.java
+++ b/src/main/java/com/filestack/FsClient.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Callable;
 import retrofit2.Response;
 
 /** Uploads new files. */
-public class FilestackClient {
+public class FsClient {
   private String apiKey;
   private Security security;
   private FsService fsService;
@@ -30,7 +30,7 @@ public class FilestackClient {
    *
    * @param apiKey account key from the dev portal
    */
-  public FilestackClient(String apiKey) {
+  public FsClient(String apiKey) {
     this(apiKey, null);
   }
 
@@ -40,7 +40,7 @@ public class FilestackClient {
    * @param apiKey   account key from the dev portal
    * @param security configured security object
    */
-  public FilestackClient(String apiKey, Security security) {
+  public FsClient(String apiKey, Security security) {
     this(apiKey, security, null);
   }
 
@@ -51,7 +51,7 @@ public class FilestackClient {
    * @param security  configured security object
    * @param fsService service to use for API calls, overrides default singleton
    */
-  public FilestackClient(String apiKey, Security security, FsService fsService) {
+  public FsClient(String apiKey, Security security, FsService fsService) {
     this.apiKey = apiKey;
     this.security = security;
     this.fsService = fsService != null ? fsService : new FsService();

--- a/src/main/java/com/filestack/FsClient.java
+++ b/src/main/java/com/filestack/FsClient.java
@@ -74,7 +74,7 @@ public class FsClient {
    * @param intelligent intelligent ingestion, setting to true to will decrease failures in very
    *                    poor network conditions at the expense of upload speed
    * @return new {@link FsFile} referencing file
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on error reading file or network failure
    */
   public FsFile upload(String path, boolean intelligent, StorageOptions options)
@@ -90,7 +90,7 @@ public class FsClient {
   /**
    * Gets basic account info for this client's API key.
    *
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public AppInfo getAppInfo() throws IOException {
@@ -116,7 +116,7 @@ public class FsClient {
    * @param providerName one of the static CLOUD constants in this class
    * @param next         pagination token returned in previous response
    *
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public CloudResponse getCloudItems(String providerName, String path, String next)
@@ -151,7 +151,7 @@ public class FsClient {
    * @param providerName one of the static CLOUD constants in this class
    * @param options      storage options for how to save the file in Filestack
    * @return             new filelink
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public FsFile storeCloudItem(String providerName, String path, StorageOptions options)
@@ -175,7 +175,7 @@ public class FsClient {
    * Logs out from specified cloud.
    *
    * @param providerName one of the static CLOUD constants in this class
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public void logoutCloud(String providerName) throws IOException {

--- a/src/main/java/com/filestack/FsFile.java
+++ b/src/main/java/com/filestack/FsFile.java
@@ -106,7 +106,7 @@ public class FsFile {
    * Returns the content of a file.
    *
    * @return byte[] of file content
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public ResponseBody getContent() throws IOException {
@@ -135,7 +135,7 @@ public class FsFile {
    *
    * @param directory location to save the file in
    * @param filename  local name for the file
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on error creating file or network failure
    */
   public File download(String directory, String filename) throws IOException {
@@ -171,7 +171,7 @@ public class FsFile {
    * Does not update the filename or MIME type.
    *
    * @param pathname path to the file, can be local or absolute
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on error reading file or network failure
    */
   public void overwrite(String pathname) throws IOException {
@@ -195,7 +195,7 @@ public class FsFile {
   /**
    * Deletes a file handle. Requires security to be set.
    *
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public void delete() throws IOException {
@@ -224,7 +224,7 @@ public class FsFile {
   /**
    * Returns tags from the Google Vision API for image FileLinks.
    *
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    *
    * @see <a href="https://www.filestack.com/docs/tagging"></a>
@@ -245,7 +245,7 @@ public class FsFile {
   /**
    * Determines if an image FsFile is "safe for work" using the Google Vision API.
    *
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    *
    * @see <a href="https://www.filestack.com/docs/tagging"></a>

--- a/src/main/java/com/filestack/FsFile.java
+++ b/src/main/java/com/filestack/FsFile.java
@@ -61,7 +61,7 @@ public class FsFile {
   FsFile() {}
 
   /**
-   * Builds new {@link FilestackClient}.
+   * Builds new {@link FsClient}.
    */
   public static class Builder {
     private String apiKey;

--- a/src/main/java/com/filestack/FsFile.java
+++ b/src/main/java/com/filestack/FsFile.java
@@ -27,7 +27,7 @@ import okio.Okio;
 import retrofit2.Response;
 
 /** References and performs operations on an individual file. */
-public class FileLink {
+public class FsFile {
   private String apiKey;
   private String handle;
   private Security security;
@@ -37,9 +37,9 @@ public class FileLink {
   /**
    * Constructs an instance without security.
    *
-   * @see #FileLink(String, String, Security)
+   * @see #FsFile(String, String, Security)
    */
-  public FileLink(String apiKey, String handle) {
+  public FsFile(String apiKey, String handle) {
     this(apiKey, handle, null);
   }
 
@@ -50,7 +50,7 @@ public class FileLink {
    * @param handle   id for a file, first path segment in dev portal urls
    * @param security needs required permissions for your intended actions
    */
-  public FileLink(String apiKey, String handle, Security security) {
+  public FsFile(String apiKey, String handle, Security security) {
     this.apiKey = apiKey;
     this.handle = handle;
     this.security = security;
@@ -58,7 +58,7 @@ public class FileLink {
     this.fsService = new FsService();
   }
 
-  FileLink() {}
+  FsFile() {}
 
   /**
    * Builds new {@link FilestackClient}.
@@ -90,15 +90,15 @@ public class FileLink {
     }
 
     /**
-     * Create the {@link FileLink} using the configured values.
+     * Create the {@link FsFile} using the configured values.
      */
-    public FileLink build() {
-      FileLink fileLink = new FileLink();
-      fileLink.apiKey = apiKey;
-      fileLink.handle = handle;
-      fileLink.security = security;
-      fileLink.fsService = fsService != null ? fsService : new FsService();
-      return fileLink;
+    public FsFile build() {
+      FsFile fsFile = new FsFile();
+      fsFile.apiKey = apiKey;
+      fsFile.handle = handle;
+      fsFile.security = security;
+      fsFile.fsService = fsService != null ? fsService : new FsService();
+      return fsFile;
     }
   }
 
@@ -243,7 +243,7 @@ public class FileLink {
   }
 
   /**
-   * Determines if an image FileLink is "safe for work" using the Google Vision API.
+   * Determines if an image FsFile is "safe for work" using the Google Vision API.
    *
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
@@ -378,7 +378,7 @@ public class FileLink {
   }
 
   /**
-   * Asynchronously determines if an image FileLink is "safe for work" using the Google Vision API.
+   * Asynchronously determines if an image FsFile is "safe for work" using the Google Vision API.
    *
    * @see #imageSfw()
    */

--- a/src/main/java/com/filestack/FsSources.java
+++ b/src/main/java/com/filestack/FsSources.java
@@ -1,0 +1,16 @@
+package com.filestack;
+
+public class FsSources {
+  public static final String FACEBOOK      = "facebook";
+  public static final String INSTAGRAM     = "instagram";
+  public static final String GOOGLE_DRIVE  = "googledrive";
+  public static final String DROPBOX       = "dropbox";
+  public static final String BOX           = "box";
+  public static final String GITHUB        = "github";
+  public static final String GMAIL         = "gmail";
+  public static final String GOOGLE_PHOTOS = "picasa";
+  public static final String ONEDRIVE      = "onedrive";
+  public static final String AMAZON_DRIVE  = "clouddrive";
+  public static final String CAMERA        = "camera";
+  public static final String DEVICE        = "device";
+}

--- a/src/main/java/com/filestack/HttpException.java
+++ b/src/main/java/com/filestack/HttpException.java
@@ -5,14 +5,14 @@ import java.io.IOException;
 /**
  * {@link IOException} subclass for backend error responses.
  */
-public class HttpResponseException extends IOException {
+public class HttpException extends IOException {
   private int code;
 
-  public HttpResponseException(int code) {
+  public HttpException(int code) {
     this.code = code;
   }
 
-  public HttpResponseException(int code, String message) {
+  public HttpException(int code, String message) {
     super(message);
     this.code = code;
   }

--- a/src/main/java/com/filestack/Security.java
+++ b/src/main/java/com/filestack/Security.java
@@ -17,7 +17,7 @@ public class Security {
   /**
    * Creates an instance from a {@link Policy Policy} object and app secret.
    * Use this to create new policy and signature pairs.
-   * Don't include your app secret in client apps.
+   * Don't include your app secret in fsClient apps.
    * Use the {@link #fromExisting(String, String) fromExisting} method instead in that case.
    *
    * @param policy    Configured {@link Policy Policy} object
@@ -36,7 +36,7 @@ public class Security {
 
   /**
    * Creates a Security object from an existing policy and signature pair.
-   * Useful for client side apps or cases where you don't want to include your app secret.
+   * Useful for fsClient side apps or cases where you don't want to include your app secret.
    *
    * @param encodedPolicy Base64URL encoded policy
    * @param signature     HMAC SHA-256 signature of policy

--- a/src/main/java/com/filestack/transforms/AvTransform.java
+++ b/src/main/java/com/filestack/transforms/AvTransform.java
@@ -16,23 +16,15 @@ import java.util.concurrent.Callable;
  */
 public class AvTransform extends Transform {
 
-  /**
-   * Constructs a new instance.
-   *
-   * @param fsFile  must point to an existing audio or video resource
-   * @param storeOpts sets how the resulting file(s) are stored, uses defaults if null
-   * @param avOps     sets conversion options
-   */
-  public AvTransform(FsFile fsFile, StorageOptions storeOpts, AvTransformOptions avOps) {
-
+  public AvTransform(FsFile fsFile, StorageOptions storeOps, AvTransformOptions avOps) {
     super(fsFile);
 
     if (avOps == null) {
       throw new IllegalArgumentException("AvTransform can't be created without options");
     }
 
-    if (storeOpts != null) {
-      tasks.add(TransformTask.merge("video_convert", storeOpts.getAsTask(), avOps));
+    if (storeOps != null) {
+      tasks.add(TransformTask.merge("video_convert", storeOps.getAsTask(), avOps));
     } else {
       tasks.add(avOps);
     }
@@ -63,7 +55,7 @@ public class AvTransform extends Transform {
           return null;
         }
         String handle = url.split("/")[3];
-        return new FsFile(apiKey, handle, security);
+        return new FsFile(fsClient, handle);
       default:
         throw new IOException("Unexpected transform error: " + json.toString());
     }
@@ -101,7 +93,7 @@ public class AvTransform extends Transform {
         return fsFile;
       }
     })
-        .subscribeOn(Schedulers.io())
-        .observeOn(Schedulers.single());
+        .subscribeOn(fsClient.getSubScheduler())
+        .observeOn(fsClient.getObsScheduler());
   }
 }

--- a/src/main/java/com/filestack/transforms/AvTransform.java
+++ b/src/main/java/com/filestack/transforms/AvTransform.java
@@ -1,6 +1,6 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.HttpResponseException;
 import com.filestack.StorageOptions;
 import com.filestack.transforms.tasks.AvTransformOptions;
@@ -19,13 +19,13 @@ public class AvTransform extends Transform {
   /**
    * Constructs a new instance.
    *
-   * @param fileLink  must point to an existing audio or video resource
+   * @param fsFile  must point to an existing audio or video resource
    * @param storeOpts sets how the resulting file(s) are stored, uses defaults if null
    * @param avOps     sets conversion options
    */
-  public AvTransform(FileLink fileLink, StorageOptions storeOpts, AvTransformOptions avOps) {
+  public AvTransform(FsFile fsFile, StorageOptions storeOpts, AvTransformOptions avOps) {
 
-    super(fileLink);
+    super(fsFile);
 
     if (avOps == null) {
       throw new IllegalArgumentException("AvTransform can't be created without options");
@@ -39,15 +39,15 @@ public class AvTransform extends Transform {
   }
 
   /**
-   * Gets converted content as a new {@link FileLink}. Starts processing on first call.
+   * Gets converted content as a new {@link FsFile}. Starts processing on first call.
    * Returns null if still processing. Poll this method or use {@link #getFileLinkAsync()}.
    * If you need other data, such as thumbnails, use {@link Transform#getContentJson()}.
    *
-   * @return null if processing, new {@link FileLink} if complete
+   * @return null if processing, new {@link FsFile} if complete
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public FileLink getFileLink() throws IOException {
+  public FsFile getFileLink() throws IOException {
     JsonObject json = getContentJson();
     String status = json.get("status").getAsString();
 
@@ -63,7 +63,7 @@ public class AvTransform extends Transform {
           return null;
         }
         String handle = url.split("/")[3];
-        return new FileLink(apiKey, handle, security);
+        return new FsFile(apiKey, handle, security);
       default:
         throw new IOException("Unexpected transform error: " + json.toString());
     }
@@ -72,33 +72,33 @@ public class AvTransform extends Transform {
   // Async method wrappers
 
   /**
-   * Asynchronously gets converted content as a new {@link FileLink}.
+   * Asynchronously gets converted content as a new {@link FsFile}.
    * Uses default 10 second polling. Use {@link #getFileLinkAsync(int)} to adjust interval.
    *
    * @see #getFileLink()
    */
-  public Single<FileLink> getFileLinkAsync() {
+  public Single<FsFile> getFileLinkAsync() {
     return getFileLinkAsync(10);
   }
 
   /**
-   * Asynchronously gets converted content as a new {@link FileLink}.
+   * Asynchronously gets converted content as a new {@link FsFile}.
    *
    * @param pollInterval how frequently to poll (in seconds)
    * @see #getFileLink()
    */
-  public Single<FileLink> getFileLinkAsync(final int pollInterval) {
-    return Single.fromCallable(new Callable<FileLink>() {
+  public Single<FsFile> getFileLinkAsync(final int pollInterval) {
+    return Single.fromCallable(new Callable<FsFile>() {
       @Override
-      public FileLink call() throws Exception {
-        FileLink fileLink = null;
-        while (fileLink == null) {
-          fileLink = getFileLink();
+      public FsFile call() throws Exception {
+        FsFile fsFile = null;
+        while (fsFile == null) {
+          fsFile = getFileLink();
           if (!Util.isUnitTest()) {
             Thread.sleep(pollInterval * 1000);
           }
         }
-        return fileLink;
+        return fsFile;
       }
     })
         .subscribeOn(Schedulers.io())

--- a/src/main/java/com/filestack/transforms/AvTransform.java
+++ b/src/main/java/com/filestack/transforms/AvTransform.java
@@ -1,7 +1,7 @@
 package com.filestack.transforms;
 
 import com.filestack.FsFile;
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 import com.filestack.StorageOptions;
 import com.filestack.transforms.tasks.AvTransformOptions;
 import com.filestack.util.Util;
@@ -44,7 +44,7 @@ public class AvTransform extends Transform {
    * If you need other data, such as thumbnails, use {@link Transform#getContentJson()}.
    *
    * @return null if processing, new {@link FsFile} if complete
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public FsFile getFileLink() throws IOException {

--- a/src/main/java/com/filestack/transforms/AvTransform.java
+++ b/src/main/java/com/filestack/transforms/AvTransform.java
@@ -7,7 +7,7 @@ import com.filestack.transforms.tasks.AvTransformOptions;
 import com.filestack.util.Util;
 import com.google.gson.JsonObject;
 import io.reactivex.Single;
-import io.reactivex.schedulers.Schedulers;
+
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
@@ -16,6 +16,9 @@ import java.util.concurrent.Callable;
  */
 public class AvTransform extends Transform {
 
+  /**
+   * Constructs new instance from a {@link FsFile} and options.
+   */
   public AvTransform(FsFile fsFile, StorageOptions storeOps, AvTransformOptions avOps) {
     super(fsFile);
 

--- a/src/main/java/com/filestack/transforms/ImageTransform.java
+++ b/src/main/java/com/filestack/transforms/ImageTransform.java
@@ -1,7 +1,7 @@
 package com.filestack.transforms;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.FilestackClient;
 import com.filestack.HttpResponseException;
 import com.filestack.StorageOptions;
 import com.filestack.util.Util;
@@ -18,7 +18,7 @@ import retrofit2.Response;
  */
 public class ImageTransform extends Transform {
 
-  public ImageTransform(FilestackClient fsClient, String source) {
+  public ImageTransform(FsClient fsClient, String source) {
     super(fsClient, source);
   }
 

--- a/src/main/java/com/filestack/transforms/ImageTransform.java
+++ b/src/main/java/com/filestack/transforms/ImageTransform.java
@@ -2,7 +2,7 @@ package com.filestack.transforms;
 
 import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 import com.filestack.StorageOptions;
 import com.filestack.util.Util;
 import com.filestack.util.responses.StoreResponse;
@@ -31,7 +31,7 @@ public class ImageTransform extends Transform {
    * @see <a href="https://www.filestack.com/docs/image-transformations/debug"></a>
    *
    * @return {@link JsonObject JSON} report for transformation
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public JsonObject debug() throws IOException {
@@ -59,7 +59,7 @@ public class ImageTransform extends Transform {
    * @see <a href="https://www.filestack.com/docs/image-transformations/store"></a>
    *
    * @return new {@link FsFile FsFile} pointing to the file
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public FsFile store() throws IOException {
@@ -72,7 +72,7 @@ public class ImageTransform extends Transform {
    *
    * @param storageOptions configure where and how your file is stored
    * @return new {@link FsFile FsFile} pointing to the file
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public FsFile store(StorageOptions storageOptions) throws IOException {

--- a/src/main/java/com/filestack/transforms/ImageTransform.java
+++ b/src/main/java/com/filestack/transforms/ImageTransform.java
@@ -1,6 +1,6 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.FilestackClient;
 import com.filestack.HttpResponseException;
 import com.filestack.StorageOptions;
@@ -22,8 +22,8 @@ public class ImageTransform extends Transform {
     super(fsClient, source);
   }
 
-  public ImageTransform(FileLink fileLink) {
-    super(fileLink);
+  public ImageTransform(FsFile fsFile) {
+    super(fsFile);
   }
 
   /**
@@ -58,11 +58,11 @@ public class ImageTransform extends Transform {
    * Stores the result of a transformation into a new file. Uses default storage options.
    * @see <a href="https://www.filestack.com/docs/image-transformations/store"></a>
    *
-   * @return new {@link FileLink FileLink} pointing to the file
+   * @return new {@link FsFile FsFile} pointing to the file
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public FileLink store() throws IOException {
+  public FsFile store() throws IOException {
     return store(null);
   }
 
@@ -71,11 +71,11 @@ public class ImageTransform extends Transform {
    * @see <a href="https://www.filestack.com/docs/image-transformations/store"></a>
    *
    * @param storageOptions configure where and how your file is stored
-   * @return new {@link FileLink FileLink} pointing to the file
+   * @return new {@link FsFile FsFile} pointing to the file
    * @throws HttpResponseException on error response from backend
    * @throws IOException           on network failure
    */
-  public FileLink store(StorageOptions storageOptions) throws IOException {
+  public FsFile store(StorageOptions storageOptions) throws IOException {
     if (storageOptions == null) {
       storageOptions = new StorageOptions();
     }
@@ -98,7 +98,7 @@ public class ImageTransform extends Transform {
     }
 
     String handle = body.getUrl().split("/")[3];
-    return new FileLink(apiKey, handle, security);
+    return new FsFile(apiKey, handle, security);
   }
 
   /**
@@ -135,7 +135,7 @@ public class ImageTransform extends Transform {
    * Async, observable version of {@link #store()}.
    * Same exceptions are passed through observable.
    */
-  public Single<FileLink> storeAsync() {
+  public Single<FsFile> storeAsync() {
     return storeAsync(null);
   }
 
@@ -143,10 +143,10 @@ public class ImageTransform extends Transform {
    * Async, observable version of {@link #store(StorageOptions)}.
    * Same exceptions are passed through observable.
    */
-  public Single<FileLink> storeAsync(final StorageOptions storageOptions) {
-    return Single.fromCallable(new Callable<FileLink>() {
+  public Single<FsFile> storeAsync(final StorageOptions storageOptions) {
+    return Single.fromCallable(new Callable<FsFile>() {
       @Override
-      public FileLink call() throws Exception {
+      public FsFile call() throws Exception {
         return store(storageOptions);
       }
     })

--- a/src/main/java/com/filestack/transforms/ImageTransform.java
+++ b/src/main/java/com/filestack/transforms/ImageTransform.java
@@ -8,10 +8,10 @@ import com.filestack.util.Util;
 import com.filestack.util.responses.StoreResponse;
 import com.google.gson.JsonObject;
 import io.reactivex.Single;
-import io.reactivex.schedulers.Schedulers;
+import retrofit2.Response;
+
 import java.io.IOException;
 import java.util.concurrent.Callable;
-import retrofit2.Response;
 
 /**
  * {@link Transform Transform} subclass for image transformations.
@@ -38,15 +38,15 @@ public class ImageTransform extends Transform {
     String tasksString = getTasksString();
 
     Response<JsonObject> response;
-    if (isExternal) {
+    if (url != null) {
       response = fsClient.getFsService()
           .cdn()
-          .transformDebugExt(fsClient.getApiKey(), tasksString, source)
+          .transformDebugExt(fsClient.getApiKey(), tasksString, url)
           .execute();
     } else {
       response = fsClient.getFsService()
           .cdn()
-          .transformDebug(tasksString, source)
+          .transformDebug(tasksString, fsFile.getHandle())
           .execute();
     }
 
@@ -90,15 +90,15 @@ public class ImageTransform extends Transform {
 
     Response<StoreResponse> response;
     String tasksString = getTasksString();
-    if (isExternal) {
+    if (url != null) {
       response = fsClient.getFsService()
           .cdn()
-          .transformStoreExt(fsClient.getApiKey(), tasksString, source)
+          .transformStoreExt(fsClient.getApiKey(), tasksString, url)
           .execute();
     } else {
       response = fsClient.getFsService()
           .cdn()
-          .transformStore(tasksString, source)
+          .transformStore(tasksString, fsFile.getHandle())
           .execute();
     }
 

--- a/src/main/java/com/filestack/transforms/ImageTransform.java
+++ b/src/main/java/com/filestack/transforms/ImageTransform.java
@@ -18,12 +18,12 @@ import retrofit2.Response;
  */
 public class ImageTransform extends Transform {
 
-  public ImageTransform(FsClient fsClient, String source) {
-    super(fsClient, source);
-  }
-
   public ImageTransform(FsFile fsFile) {
     super(fsFile);
+  }
+
+  public ImageTransform(FsClient fsClient, String url) {
+    super(fsClient, url);
   }
 
   /**
@@ -38,10 +38,16 @@ public class ImageTransform extends Transform {
     String tasksString = getTasksString();
 
     Response<JsonObject> response;
-    if (apiKey != null) {
-      response = fsService.cdn().transformDebugExt(apiKey, tasksString, source).execute();
+    if (isExternal) {
+      response = fsClient.getFsService()
+          .cdn()
+          .transformDebugExt(fsClient.getApiKey(), tasksString, source)
+          .execute();
     } else {
-      response = fsService.cdn().transformDebug(tasksString, source).execute();
+      response = fsClient.getFsService()
+          .cdn()
+          .transformDebug(tasksString, source)
+          .execute();
     }
 
     Util.checkResponseAndThrow(response);
@@ -84,10 +90,16 @@ public class ImageTransform extends Transform {
 
     Response<StoreResponse> response;
     String tasksString = getTasksString();
-    if (apiKey != null) {
-      response = fsService.cdn().transformStoreExt(apiKey, tasksString, source).execute();
+    if (isExternal) {
+      response = fsClient.getFsService()
+          .cdn()
+          .transformStoreExt(fsClient.getApiKey(), tasksString, source)
+          .execute();
     } else {
-      response = fsService.cdn().transformStore(tasksString, source).execute();
+      response = fsClient.getFsService()
+          .cdn()
+          .transformStore(tasksString, source)
+          .execute();
     }
 
     Util.checkResponseAndThrow(response);
@@ -98,7 +110,7 @@ public class ImageTransform extends Transform {
     }
 
     String handle = body.getUrl().split("/")[3];
-    return new FsFile(apiKey, handle, security);
+    return new FsFile(fsClient, handle);
   }
 
   /**
@@ -127,8 +139,8 @@ public class ImageTransform extends Transform {
         return debug();
       }
     })
-        .subscribeOn(Schedulers.io())
-        .observeOn(Schedulers.single());
+        .subscribeOn(fsClient.getSubScheduler())
+        .observeOn(fsClient.getObsScheduler());
   }
 
   /**
@@ -150,7 +162,7 @@ public class ImageTransform extends Transform {
         return store(storageOptions);
       }
     })
-        .subscribeOn(Schedulers.io())
-        .observeOn(Schedulers.single());
+        .subscribeOn(fsClient.getSubScheduler())
+        .observeOn(fsClient.getObsScheduler());
   }
 }

--- a/src/main/java/com/filestack/transforms/Transform.java
+++ b/src/main/java/com/filestack/transforms/Transform.java
@@ -2,7 +2,7 @@ package com.filestack.transforms;
 
 import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 import com.filestack.Security;
 import com.filestack.util.FsService;
 import com.filestack.util.Util;
@@ -101,7 +101,7 @@ public class Transform {
    * Returns the content of a transformation.
    *
    * @return raw transformation content, streamable
-   * @throws HttpResponseException on error response from backend
+   * @throws HttpException on error response from backend
    * @throws IOException           on network failure
    */
   public ResponseBody getContent() throws IOException {

--- a/src/main/java/com/filestack/transforms/Transform.java
+++ b/src/main/java/com/filestack/transforms/Transform.java
@@ -1,7 +1,7 @@
 package com.filestack.transforms;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.FilestackClient;
 import com.filestack.HttpResponseException;
 import com.filestack.Security;
 import com.filestack.util.FsService;
@@ -29,7 +29,7 @@ public class Transform {
 
   FsService fsService;
 
-  Transform(FilestackClient fsClient, String url) {
+  Transform(FsClient fsClient, String url) {
     this(fsClient, null, url);
   }
 
@@ -37,7 +37,7 @@ public class Transform {
     this(null, fsFile, null);
   }
 
-  Transform(FilestackClient fsClient, FsFile fsFile, String url) {
+  Transform(FsClient fsClient, FsFile fsFile, String url) {
     if (fsClient != null) {
       this.apiKey = fsClient.getApiKey();
       this.source = url;

--- a/src/main/java/com/filestack/transforms/Transform.java
+++ b/src/main/java/com/filestack/transforms/Transform.java
@@ -1,6 +1,6 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.FilestackClient;
 import com.filestack.HttpResponseException;
 import com.filestack.Security;
@@ -33,23 +33,23 @@ public class Transform {
     this(fsClient, null, url);
   }
 
-  Transform(FileLink fileLink) {
-    this(null, fileLink, null);
+  Transform(FsFile fsFile) {
+    this(null, fsFile, null);
   }
 
-  Transform(FilestackClient fsClient, FileLink fileLink, String url) {
+  Transform(FilestackClient fsClient, FsFile fsFile, String url) {
     if (fsClient != null) {
       this.apiKey = fsClient.getApiKey();
       this.source = url;
       this.fsService = fsClient.getFsService();
     } else {
-      this.source = fileLink.getHandle();
-      this.fsService = fileLink.getFsService();
+      this.source = fsFile.getHandle();
+      this.fsService = fsFile.getFsService();
     }
 
     this.tasks = new ArrayList<>();
 
-    Security security = fsClient != null ? fsClient.getSecurity() : fileLink.getSecurity();
+    Security security = fsClient != null ? fsClient.getSecurity() : fsFile.getSecurity();
     this.security = security;
     if (security != null) {
       TransformTask securityTask = new TransformTask("security");
@@ -77,7 +77,7 @@ public class Transform {
 
   /**
    * Generates a URL of the transformation.
-   * Includes the related {@link FileLink FileLink's} policy and signature.
+   * Includes the related {@link FsFile FsFile's} policy and signature.
    *
    * @return transformation URL
    */

--- a/src/main/java/com/filestack/util/FsCloudService.java
+++ b/src/main/java/com/filestack/util/FsCloudService.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.AccountInfo;
+import com.filestack.AppInfo;
 import com.google.gson.JsonObject;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -11,7 +11,7 @@ public interface FsCloudService {
   String URL = "https://cloud.rc.filepickerapp.com/";
 
   @POST("prefetch")
-  Call<AccountInfo> prefetch(@Body JsonObject body);
+  Call<AppInfo> prefetch(@Body JsonObject body);
 
   @POST("folder/list")
   Call<JsonObject> list(@Body JsonObject body);

--- a/src/main/java/com/filestack/util/FsCloudService.java
+++ b/src/main/java/com/filestack/util/FsCloudService.java
@@ -8,7 +8,7 @@ import retrofit2.http.Body;
 import retrofit2.http.POST;
 
 public interface FsCloudService {
-  String URL = "https://cloud.rc.filepickerapp.com/";
+  String URL = "https://cloud.filestackapi.com/";
 
   @POST("prefetch")
   Call<AppInfo> prefetch(@Body JsonObject body);

--- a/src/main/java/com/filestack/util/Networking.java
+++ b/src/main/java/com/filestack/util/Networking.java
@@ -17,7 +17,7 @@ public class Networking {
   private static FsUploadService fsUploadService;
   private static FsCloudService fsCloudService;
 
-  /** Get http client singleton. */
+  /** Get http fsClient singleton. */
   public static OkHttpClient getHttpClient() {
     if (httpClient == null) {
       httpClient = new OkHttpClient.Builder()
@@ -75,7 +75,7 @@ public class Networking {
     return fsCloudService;
   }
 
-  /** Set a custom http client. */
+  /** Set a custom http fsClient. */
   public static void setCustomClient(OkHttpClient client) {
     if (client == null) {
       return;

--- a/src/main/java/com/filestack/util/ProgMapFunc.java
+++ b/src/main/java/com/filestack/util/ProgMapFunc.java
@@ -1,13 +1,13 @@
 package com.filestack.util;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.Progress;
 import io.reactivex.Flowable;
 import io.reactivex.functions.Function;
 import java.util.List;
 import org.reactivestreams.Publisher;
 
-public class ProgMapFunc implements Function<List<Prog<FileLink>>, Publisher<Progress<FileLink>>> {
+public class ProgMapFunc implements Function<List<Prog<FsFile>>, Publisher<Progress<FsFile>>> {
   private final Upload upload;
   private final long startTime = System.currentTimeMillis();
 
@@ -19,15 +19,15 @@ public class ProgMapFunc implements Function<List<Prog<FileLink>>, Publisher<Pro
   }
 
   @Override
-  public Publisher<Progress<FileLink>> apply(List<Prog<FileLink>> progs) throws Exception {
+  public Publisher<Progress<FsFile>> apply(List<Prog<FsFile>> progs) throws Exception {
     // Skip update if buffer is empty
     if (progs.size() == 0) {
       return Flowable.empty();
     }
 
     int bytes = 0;
-    FileLink data = null;
-    for (Prog<FileLink> simple : progs) {
+    FsFile data = null;
+    for (Prog<FsFile> simple : progs) {
       bytes += simple.getBytes();
       data = simple.getData();
     }

--- a/src/main/java/com/filestack/util/Upload.java
+++ b/src/main/java/com/filestack/util/Upload.java
@@ -1,7 +1,7 @@
 package com.filestack.util;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.FilestackClient;
 import com.filestack.Progress;
 import com.filestack.Security;
 import com.filestack.StorageOptions;
@@ -38,7 +38,7 @@ public class Upload {
 
   /** Constructs new instance. */
   public Upload(String path, boolean intelligent, StorageOptions options,
-                FilestackClient fsClient, FsService fsService) {
+                FsClient fsClient, FsService fsService) {
 
     this.path = path;
     mediaType = options.getMediaType();

--- a/src/main/java/com/filestack/util/Upload.java
+++ b/src/main/java/com/filestack/util/Upload.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.FilestackClient;
 import com.filestack.Progress;
 import com.filestack.Security;
@@ -70,23 +70,23 @@ public class Upload {
    *
    * @return {@link Flowable} that emits {@link Progress} events
    */
-  public Flowable<Progress<FileLink>> runAsync() {
-    Flowable<Prog<FileLink>> startFlow = Flowable
+  public Flowable<Progress<FsFile>> runAsync() {
+    Flowable<Prog<FsFile>> startFlow = Flowable
         .fromCallable(new UploadStartFunc(this))
         .subscribeOn(Schedulers.io());
 
     // Create multiple func instances to each upload a subrange of parts from the file
     // Merge each of these together into one so they're executed concurrently
-    Flowable<Prog<FileLink>> transferFlow = Flowable.empty();
+    Flowable<Prog<FsFile>> transferFlow = Flowable.empty();
     for (int i = 0; i < CONCURRENCY; i++) {
       UploadTransferFunc func = new UploadTransferFunc(this, i);
-      Flowable<Prog<FileLink>> temp = Flowable
+      Flowable<Prog<FsFile>> temp = Flowable
           .create(func, BackpressureStrategy.BUFFER)
           .subscribeOn(Schedulers.io());
       transferFlow = transferFlow.mergeWith(temp);
     }
 
-    Flowable<Prog<FileLink>> completeFlow = Flowable
+    Flowable<Prog<FsFile>> completeFlow = Flowable
         .fromCallable(new UploadCompleteFunc(this))
         .subscribeOn(Schedulers.io());
 

--- a/src/main/java/com/filestack/util/UploadCompleteFunc.java
+++ b/src/main/java/com/filestack/util/UploadCompleteFunc.java
@@ -43,12 +43,15 @@ public class UploadCompleteFunc implements Callable<Prog<FsFile>> {
 
       @Override
       Response<CompleteResponse> work() throws Exception {
-        return upload.fsService.upload().complete(params).execute();
+        return upload.fsClient.getFsService()
+            .upload()
+            .complete(params)
+            .execute();
       }
     };
 
     CompleteResponse response = func.call();
-    FsFile fsFile = new FsFile(upload.apiKey, response.getHandle(), upload.security);
+    FsFile fsFile = new FsFile(upload.fsClient, response.getHandle());
 
     return new Prog<>(fsFile);
   }

--- a/src/main/java/com/filestack/util/UploadCompleteFunc.java
+++ b/src/main/java/com/filestack/util/UploadCompleteFunc.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.util.responses.CompleteResponse;
 import io.reactivex.Flowable;
 import java.util.HashMap;
@@ -16,7 +16,7 @@ import retrofit2.Response;
  * 202 response while the parts are still processing. In this case the {@link RetryNetworkFunc}
  * will handle it like a failure and automatically retry.
  */
-public class UploadCompleteFunc implements Callable<Prog<FileLink>> {
+public class UploadCompleteFunc implements Callable<Prog<FsFile>> {
   private Upload upload;
   
   UploadCompleteFunc(Upload upload) {
@@ -24,7 +24,7 @@ public class UploadCompleteFunc implements Callable<Prog<FileLink>> {
   }
   
   @Override
-  public Prog<FileLink> call() throws Exception {
+  public Prog<FsFile> call() throws Exception {
     final HashMap<String, RequestBody> params = new HashMap<>();
     params.putAll(upload.baseParams);
 
@@ -48,8 +48,8 @@ public class UploadCompleteFunc implements Callable<Prog<FileLink>> {
     };
 
     CompleteResponse response = func.call();
-    FileLink fileLink = new FileLink(upload.apiKey, response.getHandle(), upload.security);
+    FsFile fsFile = new FsFile(upload.apiKey, response.getHandle(), upload.security);
 
-    return new Prog<>(fileLink);
+    return new Prog<>(fsFile);
   }
 }

--- a/src/main/java/com/filestack/util/UploadStartFunc.java
+++ b/src/main/java/com/filestack/util/UploadStartFunc.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.util.responses.StartResponse;
 import io.reactivex.Flowable;
 import java.io.File;
@@ -11,7 +11,7 @@ import retrofit2.Response;
  * Function to be passed to {@link Flowable#fromCallable(Callable)}.
  * Handles initiating a multipart upload.
  */
-public class UploadStartFunc implements Callable<Prog<FileLink>> {
+public class UploadStartFunc implements Callable<Prog<FsFile>> {
   private final Upload upload;
   
   UploadStartFunc(Upload upload) {
@@ -19,7 +19,7 @@ public class UploadStartFunc implements Callable<Prog<FileLink>> {
   }
 
   @Override
-  public Prog<FileLink> call() throws Exception {
+  public Prog<FsFile> call() throws Exception {
     // Open the file here so that any exceptions with it get passed through the observable
     // Otherwise we'd have an async method that directly throws exceptions
     File file = Util.createReadFile(upload.path);

--- a/src/main/java/com/filestack/util/UploadStartFunc.java
+++ b/src/main/java/com/filestack/util/UploadStartFunc.java
@@ -34,7 +34,10 @@ public class UploadStartFunc implements Callable<Prog<FsFile>> {
     func = new RetryNetworkFunc<StartResponse>(0, 5, Upload.DELAY_BASE) {
       @Override
       Response<StartResponse> work() throws Exception {
-        return upload.fsService.upload().start(upload.baseParams).execute();
+        return upload.fsClient.getFsService()
+            .upload()
+            .start(upload.baseParams)
+            .execute();
       }
     };
 

--- a/src/main/java/com/filestack/util/UploadTransferFunc.java
+++ b/src/main/java/com/filestack/util/UploadTransferFunc.java
@@ -127,7 +127,10 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FsFile>> {
     func = new RetryNetworkFunc<UploadResponse>(5, 5, Upload.DELAY_BASE) {
       @Override
       Response<UploadResponse> work() throws Exception {
-        return upload.fsService.upload().upload(params).execute();
+        return upload.fsClient.getFsService()
+            .upload()
+            .upload(params)
+            .execute();
       }
     };
 
@@ -150,7 +153,10 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FsFile>> {
         String url = params.getUrl();
 
         RequestBody requestBody = RequestBody.create(upload.mediaType, bytes, 0, attemptSize);
-        return upload.fsService.upload().uploadS3(headers, url, requestBody).execute();
+        return upload.fsClient.getFsService()
+            .upload()
+            .uploadS3(headers, url, requestBody)
+            .execute();
       }
 
       @Override
@@ -184,7 +190,10 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FsFile>> {
     func = new RetryNetworkFunc<ResponseBody>(5, 5, Upload.DELAY_BASE) {
       @Override
       Response<ResponseBody> work() throws Exception {
-        return upload.fsService.upload().commit(params).execute();
+        return upload.fsClient.getFsService()
+            .upload()
+            .commit(params)
+            .execute();
       }
     };
 

--- a/src/main/java/com/filestack/util/UploadTransferFunc.java
+++ b/src/main/java/com/filestack/util/UploadTransferFunc.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.util.responses.UploadResponse;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -23,7 +23,7 @@ import retrofit2.Response;
  * An upload should be divided between multiple instances, with each uploading a subrange of parts.
  * We take a sectionIndex that tells us what area of the file to be responsible for.
  */
-public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
+public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FsFile>> {
   private Upload upload;
   private int sectionIndex;
 
@@ -33,7 +33,7 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
   }
 
   @Override
-  public void subscribe(FlowableEmitter<Prog<FileLink>> e) throws Exception {
+  public void subscribe(FlowableEmitter<Prog<FsFile>> e) throws Exception {
     int start = sectionIndex * upload.partsPerFunc;
     int count = Math.min(upload.partsPerFunc, upload.numParts - start);
 
@@ -80,7 +80,7 @@ public class UploadTransferFunc implements FlowableOnSubscribe<Prog<FileLink>> {
         }
 
         bytesSent = uploadToS3(upload, part, offset, bytesRead, bytes);
-        e.onNext(new Prog<FileLink>(bytesSent));
+        e.onNext(new Prog<FsFile>(bytesSent));
 
         if (bytesSent < bytesRead) {
           if (bytesSent < Upload.MIN_CHUNK_SIZE) {

--- a/src/main/java/com/filestack/util/Util.java
+++ b/src/main/java/com/filestack/util/Util.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -56,27 +56,27 @@ public class Util {
   }
 
   /**
-   * Throws an {@link HttpResponseException} with the code and error body from a {@link Response}.
+   * Throws an {@link HttpException} with the code and error body from a {@link Response}.
    *
    * @param response response from a backend call
-   * @throws HttpResponseException always unless error reading response body
+   * @throws HttpException always unless error reading response body
    * @throws IOException           on error reading response body
    */
   public static void throwHttpResponseException(Response response) throws IOException {
     ResponseBody errorBody = response.errorBody();
     if (errorBody != null) {
-      throw new HttpResponseException(response.code(), errorBody.string());
+      throw new HttpException(response.code(), errorBody.string());
     } else {
-      throw new HttpResponseException(response.code());
+      throw new HttpException(response.code());
     }
   }
 
   /**
    * Checks status of backend responses.
-   * Throws a {@link HttpResponseException} if response isn't in 200 range.
+   * Throws a {@link HttpException} if response isn't in 200 range.
    *
    * @param response response from a backend call
-   * @throws HttpResponseException on response code not in 200 range
+   * @throws HttpException on response code not in 200 range
    * @throws IOException           on error reading response body
    */
   public static void checkResponseAndThrow(Response response) throws IOException {

--- a/src/test/java/com/filestack/TestFilestackClient.java
+++ b/src/test/java/com/filestack/TestFilestackClient.java
@@ -175,9 +175,9 @@ public class TestFilestackClient {
 
     Path path = createRandomFile(10 * 1024 * 1024);
 
-    FileLink fileLink = client.upload(path.toString(), false);
+    FsFile fsFile = client.upload(path.toString(), false);
 
-    Assert.assertEquals("handle", fileLink.getHandle());
+    Assert.assertEquals("handle", fsFile.getHandle());
 
     Files.delete(path);
   }

--- a/src/test/java/com/filestack/TestFsClient.java
+++ b/src/test/java/com/filestack/TestFsClient.java
@@ -29,9 +29,9 @@ import retrofit2.Response;
 import retrofit2.mock.Calls;
 
 /**
- * Tests {@link FilestackClient FilestackClient} class.
+ * Tests {@link FsClient FsClient} class.
  */
-public class TestFilestackClient {
+public class TestFsClient {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -143,8 +143,8 @@ public class TestFilestackClient {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "app_secret");
 
-    FilestackClient client1 = new FilestackClient("apiKey");
-    FilestackClient client2 = new FilestackClient("apiKey", security);
+    FsClient client1 = new FsClient("apiKey");
+    FsClient client2 = new FsClient("apiKey", security);
   }
 
   @Test
@@ -152,7 +152,7 @@ public class TestFilestackClient {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "app_secret");
 
-    FilestackClient client = new FilestackClient("apiKey", security);
+    FsClient client = new FsClient("apiKey", security);
     thrown.expect(FileNotFoundException.class);
     client.upload("/does_not_exist.txt", true);
   }
@@ -171,7 +171,7 @@ public class TestFilestackClient {
     Security security = Security.createNew(policy, "app_secret");
 
     FsService mockFsService = new FsService(null, null, mockUploadService, null);
-    FilestackClient client = new FilestackClient("apiKey", security, mockFsService);
+    FsClient client = new FsClient("apiKey", security, mockFsService);
 
     Path path = createRandomFile(10 * 1024 * 1024);
 

--- a/src/test/java/com/filestack/TestFsFile.java
+++ b/src/test/java/com/filestack/TestFsFile.java
@@ -19,17 +19,17 @@ import retrofit2.Call;
 import retrofit2.mock.Calls;
 
 /**
- * Tests {@link FileLink FileLink} class.
+ * Tests {@link FsFile FsFile} class.
  */
-public class TestFileLink {
+public class TestFsFile {
 
   @Test
   public void testConstructors() {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "app_secret");
 
-    FileLink fileLink1 = new FileLink("apiKey", "handle");
-    FileLink fileLink2 = new FileLink("apiKey", "handle", security);
+    FsFile fsFile1 = new FsFile("apiKey", "handle");
+    FsFile fsFile2 = new FsFile("apiKey", "handle", security);
   }
 
   @Test
@@ -45,13 +45,13 @@ public class TestFileLink {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
         .build();
 
-    ResponseBody content = fileLink.getContent();
+    ResponseBody content = fsFile.getContent();
     Assert.assertEquals("Test content", content.string());
   }
 
@@ -68,13 +68,13 @@ public class TestFileLink {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
         .build();
 
-    File file = fileLink.download("/tmp/");
+    File file = fsFile.download("/tmp/");
     Assert.assertTrue(file.isFile());
     if (!file.delete()) {
       Assert.fail("Unable to cleanup resource");
@@ -94,13 +94,13 @@ public class TestFileLink {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
         .build();
 
-    File file = fileLink.download("/tmp/", "filestack_test_filelink_download.txt");
+    File file = fsFile.download("/tmp/", "filestack_test_filelink_download.txt");
     Assert.assertTrue(file.isFile());
     if (!file.delete()) {
       Assert.fail("Unable to cleanup resource");
@@ -135,14 +135,14 @@ public class TestFileLink {
 
     FsService mockFsService = new FsService(mockApiService, null, null, null);
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .security(security)
         .service(mockFsService)
         .build();
 
-    fileLink.overwrite(pathname);
+    fsFile.overwrite(pathname);
 
     if (!file.delete()) {
       Assert.fail("Unable to cleanup resource");
@@ -165,41 +165,41 @@ public class TestFileLink {
         .when(mockApiService)
         .delete("handle", "apiKey", security.getPolicy(), security.getSignature());
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .security(security)
         .service(mockFsService)
         .build();
 
-    fileLink.delete();
+    fsFile.delete();
   }
 
   @Test(expected = IllegalStateException.class)
   public void testOverwriteWithoutSecurity() throws Exception {
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    fileLink.overwrite("");
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    fsFile.overwrite("");
   }
 
   @Test(expected = FileNotFoundException.class)
   public void testOverwriteNoFile() throws Exception {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "appSecret");
-    FileLink fileLink = new FileLink("apiKey", "handle", security);
+    FsFile fsFile = new FsFile("apiKey", "handle", security);
 
-    fileLink.overwrite("/tmp/filestack_test_overwrite_no_file.txt");
+    fsFile.overwrite("/tmp/filestack_test_overwrite_no_file.txt");
   }
 
   @Test(expected = IllegalStateException.class)
   public void testDeleteWithoutSecurity() throws Exception {
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    fileLink.delete();
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    fsFile.delete();
   }
 
   @Test(expected = IllegalStateException.class)
   public void testImageTagNoSecurity() throws Exception {
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    fileLink.imageTags();
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    fsFile.imageTags();
   }
 
   @Test
@@ -231,22 +231,22 @@ public class TestFileLink {
         .when(mockCdnService)
         .transform(tasksString, "handle");
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .security(security)
         .service(mockFsService)
         .build();
 
-    Map<String, Integer> tags = fileLink.imageTags();
+    Map<String, Integer> tags = fsFile.imageTags();
 
     Assert.assertEquals((Integer) 100, tags.get("giraffe"));
   }
 
   @Test(expected = IllegalStateException.class)
   public void testImageSfwNoSecurity() throws Exception {
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    fileLink.imageSfw();
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    fsFile.imageSfw();
   }
 
   @Test
@@ -269,13 +269,13 @@ public class TestFileLink {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "appSecret");
 
-    FileLink.Builder builder = new FileLink.Builder()
+    FsFile.Builder builder = new FsFile.Builder()
         .apiKey("apiKey")
         .security(security)
         .service(mockFsService);
 
-    FileLink safe = builder.handle("safe").build();
-    FileLink notSafe = builder.handle("notSafe").build();
+    FsFile safe = builder.handle("safe").build();
+    FsFile notSafe = builder.handle("notSafe").build();
 
     Assert.assertTrue(safe.imageSfw());
     Assert.assertFalse(notSafe.imageSfw());

--- a/src/test/java/com/filestack/TestFsFile.java
+++ b/src/test/java/com/filestack/TestFsFile.java
@@ -28,8 +28,8 @@ public class TestFsFile {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "app_secret");
 
-    FsFile fsFile1 = new FsFile("apiKey", "handle");
-    FsFile fsFile2 = new FsFile("apiKey", "handle", security);
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
   }
 
   @Test
@@ -45,11 +45,12 @@ public class TestFsFile {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     ResponseBody content = fsFile.getContent();
     Assert.assertEquals("Test content", content.string());
@@ -68,11 +69,12 @@ public class TestFsFile {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     File file = fsFile.download("/tmp/");
     Assert.assertTrue(file.isFile());
@@ -94,11 +96,12 @@ public class TestFsFile {
         .when(mockCdnService)
         .get("handle", null, null);
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     File file = fsFile.download("/tmp/", "filestack_test_filelink_download.txt");
     Assert.assertTrue(file.isFile());
@@ -135,12 +138,13 @@ public class TestFsFile {
 
     FsService mockFsService = new FsService(mockApiService, null, null, null);
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
         .security(security)
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     fsFile.overwrite(pathname);
 
@@ -165,19 +169,21 @@ public class TestFsFile {
         .when(mockApiService)
         .delete("handle", "apiKey", security.getPolicy(), security.getSignature());
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
         .security(security)
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     fsFile.delete();
   }
 
   @Test(expected = IllegalStateException.class)
   public void testOverwriteWithoutSecurity() throws Exception {
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     fsFile.overwrite("");
   }
 
@@ -185,20 +191,24 @@ public class TestFsFile {
   public void testOverwriteNoFile() throws Exception {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "appSecret");
-    FsFile fsFile = new FsFile("apiKey", "handle", security);
+
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").security(security).build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     fsFile.overwrite("/tmp/filestack_test_overwrite_no_file.txt");
   }
 
   @Test(expected = IllegalStateException.class)
   public void testDeleteWithoutSecurity() throws Exception {
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     fsFile.delete();
   }
 
   @Test(expected = IllegalStateException.class)
   public void testImageTagNoSecurity() throws Exception {
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     fsFile.imageTags();
   }
 
@@ -231,12 +241,13 @@ public class TestFsFile {
         .when(mockCdnService)
         .transform(tasksString, "handle");
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
         .security(security)
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     Map<String, Integer> tags = fsFile.imageTags();
 
@@ -245,7 +256,8 @@ public class TestFsFile {
 
   @Test(expected = IllegalStateException.class)
   public void testImageSfwNoSecurity() throws Exception {
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     fsFile.imageSfw();
   }
 
@@ -269,13 +281,16 @@ public class TestFsFile {
     Policy policy = new Policy.Builder().giveFullAccess().build();
     Security security = Security.createNew(policy, "appSecret");
 
-    FsFile.Builder builder = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
         .security(security)
-        .service(mockFsService);
+        .fsService(mockFsService)
+        .build();
 
-    FsFile safe = builder.handle("safe").build();
-    FsFile notSafe = builder.handle("notSafe").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
+
+    FsFile safe = new FsFile(fsClient, "safe");
+    FsFile notSafe = new FsFile(fsClient, "notSafe");
 
     Assert.assertTrue(safe.imageSfw());
     Assert.assertFalse(notSafe.imageSfw());

--- a/src/test/java/com/filestack/TestHttpException.java
+++ b/src/test/java/com/filestack/TestHttpException.java
@@ -3,12 +3,12 @@ package com.filestack;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestHttpResponseException {
+public class TestHttpException {
 
   @Test
   public void testCode() {
     int code = 400;
-    HttpResponseException exception = new HttpResponseException(code);
+    HttpException exception = new HttpException(code);
     Assert.assertEquals(400, exception.getCode());
     Assert.assertNull(exception.getMessage());
   }
@@ -17,7 +17,7 @@ public class TestHttpResponseException {
   public void testCodeMessage() {
     int code = 400;
     String message = "Error description... ";
-    HttpResponseException exception = new HttpResponseException(code, message);
+    HttpException exception = new HttpException(code, message);
     Assert.assertEquals(400, exception.getCode());
     Assert.assertEquals(message, exception.getMessage());
   }

--- a/src/test/java/com/filestack/transforms/TestAvTransform.java
+++ b/src/test/java/com/filestack/transforms/TestAvTransform.java
@@ -1,6 +1,6 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.StorageOptions;
 import com.filestack.transforms.tasks.AvTransformOptions;
 import com.filestack.util.FsCdnService;
@@ -20,8 +20,8 @@ public class TestAvTransform {
 
   @Test(expected = IllegalArgumentException.class)
   public void testConstructorException() {
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    fileLink.avTransform(null);
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    fsFile.avTransform(null);
   }
 
   @Test
@@ -30,8 +30,8 @@ public class TestAvTransform {
         .preset("mp4")
         .build();
 
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    TransformTask task = fileLink.avTransform(avOptions).tasks.get(0);
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    TransformTask task = fsFile.avTransform(avOptions).tasks.get(0);
 
     Assert.assertEquals("video_convert=preset:mp4", task.toString());
   }
@@ -46,8 +46,8 @@ public class TestAvTransform {
         .preset("mp4")
         .build();
 
-    FileLink fileLink = new FileLink("apiKey", "handle");
-    TransformTask task = fileLink.avTransform(storageOptions, avOptions).tasks.get(0);
+    FsFile fsFile = new FsFile("apiKey", "handle");
+    TransformTask task = fsFile.avTransform(storageOptions, avOptions).tasks.get(0);
 
     Assert.assertEquals("video_convert=container:some-bucket,preset:mp4", task.toString());
   }
@@ -71,14 +71,14 @@ public class TestAvTransform {
         .when(mockCdnService)
         .transform(Mockito.anyString(), Mockito.anyString());
 
-    FileLink.Builder builder = new FileLink.Builder().apiKey("apiKey").service(mockFsService);
+    FsFile.Builder builder = new FsFile.Builder().apiKey("apiKey").service(mockFsService);
 
-    FileLink ready = builder.handle("ready").build();
-    FileLink pending = builder.handle("pending").build();
+    FsFile ready = builder.handle("ready").build();
+    FsFile pending = builder.handle("pending").build();
 
     AvTransformOptions avOptions = new AvTransformOptions.Builder().preset("mp4").build();
 
-    FileLink converted = ready.avTransform(avOptions).getFileLink();
+    FsFile converted = ready.avTransform(avOptions).getFileLink();
     Assert.assertEquals("handle", converted.getHandle());
     Assert.assertNull(pending.avTransform(avOptions).getFileLink());
   }
@@ -97,7 +97,7 @@ public class TestAvTransform {
         .when(mockCdnService)
         .transform("video_convert=preset:mp4", "handle");
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
@@ -105,6 +105,6 @@ public class TestAvTransform {
 
     AvTransformOptions avOptions = new AvTransformOptions.Builder().preset("mp4").build();
 
-    fileLink.avTransform(avOptions).getFileLink();
+    fsFile.avTransform(avOptions).getFileLink();
   }
 }

--- a/src/test/java/com/filestack/transforms/TestAvTransform.java
+++ b/src/test/java/com/filestack/transforms/TestAvTransform.java
@@ -1,5 +1,6 @@
 package com.filestack.transforms;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
 import com.filestack.StorageOptions;
 import com.filestack.transforms.tasks.AvTransformOptions;
@@ -20,7 +21,8 @@ public class TestAvTransform {
 
   @Test(expected = IllegalArgumentException.class)
   public void testConstructorException() {
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apikey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     fsFile.avTransform(null);
   }
 
@@ -30,7 +32,8 @@ public class TestAvTransform {
         .preset("mp4")
         .build();
 
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apikey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     TransformTask task = fsFile.avTransform(avOptions).tasks.get(0);
 
     Assert.assertEquals("video_convert=preset:mp4", task.toString());
@@ -46,7 +49,8 @@ public class TestAvTransform {
         .preset("mp4")
         .build();
 
-    FsFile fsFile = new FsFile("apiKey", "handle");
+    FsClient fsClient = new FsClient.Builder().apiKey("apikey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     TransformTask task = fsFile.avTransform(storageOptions, avOptions).tasks.get(0);
 
     Assert.assertEquals("video_convert=container:some-bucket,preset:mp4", task.toString());
@@ -71,10 +75,13 @@ public class TestAvTransform {
         .when(mockCdnService)
         .transform(Mockito.anyString(), Mockito.anyString());
 
-    FsFile.Builder builder = new FsFile.Builder().apiKey("apiKey").service(mockFsService);
+    FsClient fsClient = new FsClient.Builder()
+        .apiKey("apikey")
+        .fsService(mockFsService)
+        .build();
 
-    FsFile ready = builder.handle("ready").build();
-    FsFile pending = builder.handle("pending").build();
+    FsFile ready = new FsFile(fsClient, "ready");
+    FsFile pending = new FsFile(fsClient, "pending");
 
     AvTransformOptions avOptions = new AvTransformOptions.Builder().preset("mp4").build();
 
@@ -97,11 +104,12 @@ public class TestAvTransform {
         .when(mockCdnService)
         .transform("video_convert=preset:mp4", "handle");
 
-    FsFile fsFile = new FsFile.Builder()
-        .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+    FsClient fsClient = new FsClient.Builder()
+        .apiKey("apikey")
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     AvTransformOptions avOptions = new AvTransformOptions.Builder().preset("mp4").build();
 

--- a/src/test/java/com/filestack/transforms/TestImageTransform.java
+++ b/src/test/java/com/filestack/transforms/TestImageTransform.java
@@ -1,7 +1,7 @@
 package com.filestack.transforms;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.FilestackClient;
 import com.filestack.util.FsCdnService;
 import com.filestack.util.FsService;
 import com.filestack.util.responses.StoreResponse;
@@ -68,7 +68,7 @@ public class TestImageTransform {
     String url = "https://example.com/image.jpg";
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
-    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
+    FsClient client = new FsClient("apiKey", null, mockFsService);
 
     Mockito.doReturn(Calls.response(new JsonObject()))
         .when(mockCdnService)
@@ -104,7 +104,7 @@ public class TestImageTransform {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
 
-    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
+    FsClient client = new FsClient("apiKey", null, mockFsService);
 
     String jsonString = "{'url': 'https://cdn.filestackcontent.com/handle'}";
     Gson gson = new Gson();

--- a/src/test/java/com/filestack/transforms/TestImageTransform.java
+++ b/src/test/java/com/filestack/transforms/TestImageTransform.java
@@ -1,6 +1,6 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.FilestackClient;
 import com.filestack.util.FsCdnService;
 import com.filestack.util.FsService;
@@ -50,7 +50,7 @@ public class TestImageTransform {
   public void testDebugHandle() throws Exception {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
@@ -60,7 +60,7 @@ public class TestImageTransform {
         .when(mockCdnService)
         .transformDebug("", "handle");
 
-    Assert.assertNotNull(fileLink.imageTransform().debug());
+    Assert.assertNotNull(fsFile.imageTransform().debug());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class TestImageTransform {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
@@ -96,7 +96,7 @@ public class TestImageTransform {
         .when(mockCdnService)
         .transformStore("store", "handle");
 
-    Assert.assertNotNull(fileLink.imageTransform().store());
+    Assert.assertNotNull(fsFile.imageTransform().store());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class TestImageTransform {
 
   @Test(expected = NullPointerException.class)
   public void testAddNullTask() throws Exception {
-    FileLink filelink = new FileLink("apiKey", "handle");
+    FsFile filelink = new FsFile("apiKey", "handle");
     ImageTransform transform = filelink.imageTransform();
     transform.addTask(null);
   }

--- a/src/test/java/com/filestack/transforms/TestImageTransform.java
+++ b/src/test/java/com/filestack/transforms/TestImageTransform.java
@@ -50,11 +50,12 @@ public class TestImageTransform {
   public void testDebugHandle() throws Exception {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     Mockito.doReturn(Calls.response(new JsonObject()))
         .when(mockCdnService)
@@ -68,13 +69,13 @@ public class TestImageTransform {
     String url = "https://example.com/image.jpg";
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
-    FsClient client = new FsClient("apiKey", null, mockFsService);
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").fsService(mockFsService).build();
 
     Mockito.doReturn(Calls.response(new JsonObject()))
         .when(mockCdnService)
         .transformDebugExt("apiKey", "", url);
 
-    Assert.assertNotNull(client.imageTransform(url).debug());
+    Assert.assertNotNull(fsClient.imageTransform(url).debug());
   }
 
   @Test
@@ -82,11 +83,12 @@ public class TestImageTransform {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     String jsonString = "{'url': 'https://cdn.filestackcontent.com/handle'}";
     Gson gson = new Gson();
@@ -104,7 +106,12 @@ public class TestImageTransform {
     FsCdnService mockCdnService = Mockito.mock(FsCdnService.class);
     FsService mockFsService = new FsService(null, mockCdnService, null, null);
 
-    FsClient client = new FsClient("apiKey", null, mockFsService);
+    FsClient fsClient = new FsClient.Builder()
+        .apiKey("apiKey")
+        .fsService(mockFsService)
+        .build();
+
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     String jsonString = "{'url': 'https://cdn.filestackcontent.com/handle'}";
     Gson gson = new Gson();
@@ -116,13 +123,14 @@ public class TestImageTransform {
         .when(mockCdnService)
         .transformStoreExt("apiKey", "store", url);
 
-    Assert.assertNotNull(client.imageTransform(url).store());
+    Assert.assertNotNull(fsClient.imageTransform(url).store());
   }
 
   @Test(expected = NullPointerException.class)
   public void testAddNullTask() throws Exception {
-    FsFile filelink = new FsFile("apiKey", "handle");
-    ImageTransform transform = filelink.imageTransform();
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
+    ImageTransform transform = fsFile.imageTransform();
     transform.addTask(null);
   }
 }

--- a/src/test/java/com/filestack/transforms/TestTransform.java
+++ b/src/test/java/com/filestack/transforms/TestTransform.java
@@ -1,12 +1,11 @@
 package com.filestack.transforms;
 
-import com.filestack.FileLink;
+import com.filestack.FsFile;
 import com.filestack.FilestackClient;
 import com.filestack.Policy;
 import com.filestack.Security;
 import com.filestack.util.FsCdnService;
 import com.filestack.util.FsService;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
@@ -33,9 +32,9 @@ public class TestTransform {
 
   @Test
   public void testUrlHandle() {
-    FileLink fileLink = new FileLink("apiKey", "handle");
+    FsFile fsFile = new FsFile("apiKey", "handle");
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
 
     String correctUrl = FsCdnService.URL + TASK_STRING + "/" + "handle";
@@ -56,9 +55,9 @@ public class TestTransform {
 
   @Test
   public void testUrlSecurity() {
-    FileLink fileLink = new FileLink("apikey", "handle", SECURITY);
+    FsFile fsFile = new FsFile("apikey", "handle", SECURITY);
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
 
     String correctUrl = FsCdnService.URL + "security=policy:" + SECURITY.getPolicy() + ","
@@ -68,9 +67,9 @@ public class TestTransform {
 
   @Test
   public void testUrlMultipleTasks() {
-    FileLink fileLink = new FileLink("apikey", "handle");
+    FsFile fsFile = new FsFile("apikey", "handle");
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
     transform.tasks.add(TASK);
 
@@ -80,9 +79,9 @@ public class TestTransform {
 
   @Test
   public void testUrlTaskWithoutOptions() {
-    FileLink fileLink = new FileLink("apikey", "handle");
+    FsFile fsFile = new FsFile("apikey", "handle");
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(new TransformTask("task"));
 
     String correctUrl = FsCdnService.URL + "task/handle";
@@ -121,13 +120,13 @@ public class TestTransform {
         .when(mockCdnService)
         .transform("task", "handle");
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
         .build();
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(new TransformTask("task"));
 
     Assert.assertEquals("Test Response", transform.getContent().string());
@@ -149,13 +148,13 @@ public class TestTransform {
         .when(mockCdnService)
         .transform("task", "handle");
 
-    FileLink fileLink = new FileLink.Builder()
+    FsFile fsFile = new FsFile.Builder()
         .apiKey("apiKey")
         .handle("handle")
         .service(mockFsService)
         .build();
 
-    Transform transform = new Transform(fileLink);
+    Transform transform = new Transform(fsFile);
     transform.tasks.add(new TransformTask("task"));
 
     JsonObject jsonObject = transform.getContentJson();

--- a/src/test/java/com/filestack/transforms/TestTransform.java
+++ b/src/test/java/com/filestack/transforms/TestTransform.java
@@ -32,8 +32,8 @@ public class TestTransform {
 
   @Test
   public void testUrlHandle() {
-    FsFile fsFile = new FsFile("apiKey", "handle");
-
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
 
@@ -43,10 +43,9 @@ public class TestTransform {
 
   @Test
   public void testUrlExternal() {
-    FsClient client = new FsClient("apiKey");
-
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
     String sourceUrl = "https://example.com/image.jpg";
-    Transform transform = new Transform(client, sourceUrl);
+    Transform transform = new Transform(fsClient, sourceUrl);
     transform.tasks.add(TASK);
 
     String correctUrl = FsCdnService.URL + "apiKey/" + TASK_STRING + "/" + sourceUrl;
@@ -55,8 +54,8 @@ public class TestTransform {
 
   @Test
   public void testUrlSecurity() {
-    FsFile fsFile = new FsFile("apikey", "handle", SECURITY);
-
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").security(SECURITY).build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
 
@@ -67,8 +66,8 @@ public class TestTransform {
 
   @Test
   public void testUrlMultipleTasks() {
-    FsFile fsFile = new FsFile("apikey", "handle");
-
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     Transform transform = new Transform(fsFile);
     transform.tasks.add(TASK);
     transform.tasks.add(TASK);
@@ -79,8 +78,8 @@ public class TestTransform {
 
   @Test
   public void testUrlTaskWithoutOptions() {
-    FsFile fsFile = new FsFile("apikey", "handle");
-
+    FsClient fsClient = new FsClient.Builder().apiKey("apiKey").build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
     Transform transform = new Transform(fsFile);
     transform.tasks.add(new TransformTask("task"));
 
@@ -100,9 +99,12 @@ public class TestTransform {
         .when(mockCdnService)
         .transformExt("apiKey", "task", "https://example.com/");
 
-    FsClient client = new FsClient("apiKey", null, mockFsService);
+    FsClient fsClient = new FsClient.Builder()
+        .apiKey("apiKey")
+        .fsService(mockFsService)
+        .build();
+    Transform transform = new Transform(fsClient, "https://example.com/");
 
-    Transform transform = new Transform(client, "https://example.com/");
     transform.tasks.add(new TransformTask("task"));
 
     Assert.assertEquals("Test Response", transform.getContent().string());
@@ -120,13 +122,13 @@ public class TestTransform {
         .when(mockCdnService)
         .transform("task", "handle");
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
-
+    FsFile fsFile = new FsFile(fsClient, "handle");
     Transform transform = new Transform(fsFile);
+
     transform.tasks.add(new TransformTask("task"));
 
     Assert.assertEquals("Test Response", transform.getContent().string());
@@ -148,11 +150,11 @@ public class TestTransform {
         .when(mockCdnService)
         .transform("task", "handle");
 
-    FsFile fsFile = new FsFile.Builder()
+    FsClient fsClient = new FsClient.Builder()
         .apiKey("apiKey")
-        .handle("handle")
-        .service(mockFsService)
+        .fsService(mockFsService)
         .build();
+    FsFile fsFile = new FsFile(fsClient, "handle");
 
     Transform transform = new Transform(fsFile);
     transform.tasks.add(new TransformTask("task"));

--- a/src/test/java/com/filestack/transforms/TestTransform.java
+++ b/src/test/java/com/filestack/transforms/TestTransform.java
@@ -1,7 +1,7 @@
 package com.filestack.transforms;
 
+import com.filestack.FsClient;
 import com.filestack.FsFile;
-import com.filestack.FilestackClient;
 import com.filestack.Policy;
 import com.filestack.Security;
 import com.filestack.util.FsCdnService;
@@ -43,7 +43,7 @@ public class TestTransform {
 
   @Test
   public void testUrlExternal() {
-    FilestackClient client = new FilestackClient("apiKey");
+    FsClient client = new FsClient("apiKey");
 
     String sourceUrl = "https://example.com/image.jpg";
     Transform transform = new Transform(client, sourceUrl);
@@ -100,7 +100,7 @@ public class TestTransform {
         .when(mockCdnService)
         .transformExt("apiKey", "task", "https://example.com/");
 
-    FilestackClient client = new FilestackClient("apiKey", null, mockFsService);
+    FsClient client = new FsClient("apiKey", null, mockFsService);
 
     Transform transform = new Transform(client, "https://example.com/");
     transform.tasks.add(new TransformTask("task"));

--- a/src/test/java/com/filestack/util/TestRetryNetworkFunc.java
+++ b/src/test/java/com/filestack/util/TestRetryNetworkFunc.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 import java.io.IOException;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -42,7 +42,7 @@ public class TestRetryNetworkFunc {
       }
     };
 
-    thrown.expect(HttpResponseException.class);
+    thrown.expect(HttpException.class);
     retryNetworkFunc.call();
   }
 
@@ -67,7 +67,7 @@ public class TestRetryNetworkFunc {
       }
     };
 
-    thrown.expect(HttpResponseException.class);
+    thrown.expect(HttpException.class);
     retryNetworkFunc.call();
   }
 
@@ -82,7 +82,7 @@ public class TestRetryNetworkFunc {
       }
     };
 
-    thrown.expect(HttpResponseException.class);
+    thrown.expect(HttpException.class);
     retryNetworkFunc.call();
   }
 
@@ -97,7 +97,7 @@ public class TestRetryNetworkFunc {
       }
     };
 
-    thrown.expect(HttpResponseException.class);
+    thrown.expect(HttpException.class);
     retryNetworkFunc.call();
   }
 

--- a/src/test/java/com/filestack/util/TestUtil.java
+++ b/src/test/java/com/filestack/util/TestUtil.java
@@ -1,6 +1,6 @@
 package com.filestack.util;
 
-import com.filestack.HttpResponseException;
+import com.filestack.HttpException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -28,7 +28,7 @@ public class TestUtil extends Util {
     try {
       Util.checkResponseAndThrow(response);
       Assert.fail("Should have thrown exception");
-    } catch (HttpResponseException e) {
+    } catch (HttpException e) {
       Assert.assertEquals(code, e.getCode());
       Assert.assertEquals(message, e.getMessage());
     } catch (IOException e) {


### PR DESCRIPTION
https://filestack.atlassian.net/browse/FS-2024

- Integrated Cloudrouter mobile flow
- Setup client to handle session and next tokens
- Moved cloud source constants out of FsClient
- Renamed several classes to match Android SDK (FsClass not FilestackClass)
- You need a FsClient to construct a FsFile now
    - This just makes more sense
    - It was needed for the scheduler change
- Added rxJava scheduler config to FsClient
    - It passes the schedulers to every object created from it
    - Everywhere we use observables, we now use a consistent set of schedulers
    - Needed this so we could ensure every observable observes on the UI thread in Android
- Disabled import order rule in the Checkstyle config because it was a useless pita