### PR TITLE
Uploads should get filename from path for path uploads

### DIFF
--- a/src/integTest/java/com/filestack/TestImageTagging.java
+++ b/src/integTest/java/com/filestack/TestImageTagging.java
@@ -53,7 +53,6 @@ public class TestImageTagging {
   /** Deletes any FILES uploaded during tests. */
   @AfterClass
   public static void cleanupHandles() {
-    /*
     for (String handle : HANDLES) {
       FileLink fileLink = new FileLink(config, handle);
       try {
@@ -62,7 +61,6 @@ public class TestImageTagging {
         Assert.fail("FileLink delete failed");
       }
     }
-    */
   }
 
   /** Deletes any local FILES created during tests. */

--- a/src/main/java/com/filestack/Client.java
+++ b/src/main/java/com/filestack/Client.java
@@ -5,6 +5,7 @@ import com.filestack.internal.Upload;
 import com.filestack.internal.Util;
 import com.filestack.internal.responses.CloudStoreResponse;
 import com.filestack.transforms.ImageTransform;
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -193,6 +194,13 @@ public class Client implements Serializable {
     try {
       File inputFile = Util.createReadFile(path);
       InputStream inputStream = new FileInputStream(inputFile);
+
+      if (opts == null) {
+        opts = new StorageOptions.Builder().filename(inputFile.getName()).build();
+      } else if (Strings.isNullOrEmpty(opts.getFilename())) {
+        opts = opts.newBuilder().filename(inputFile.getName()).build();
+      }
+
       return uploadAsync(inputStream, (int) inputFile.length(), intel, opts);
     } catch (IOException e) {
       return Flowable.error(e);

--- a/src/main/java/com/filestack/StorageOptions.java
+++ b/src/main/java/com/filestack/StorageOptions.java
@@ -27,6 +27,10 @@ public class StorageOptions implements Serializable {
   // Private to enforce use of the builder
   private StorageOptions() { }
 
+  public String getFilename() {
+    return filename;
+  }
+
   public String getMimeType() {
     return mimeType;
   }


### PR DESCRIPTION
Makes it match the previous behavior before InputStream uploads were added. Doesn't override a filename set in the passed StorageOptions, also as before.