### PR TITLE
Manually serialize Policy fields

### DIFF
--- a/src/main/java/com/filestack/Policy.java
+++ b/src/main/java/com/filestack/Policy.java
@@ -2,7 +2,8 @@ package com.filestack;
 
 import com.filestack.internal.Hash;
 import com.filestack.internal.Util;
-import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 import java.nio.charset.Charset;
 import java.util.Date;
@@ -148,14 +149,32 @@ public class Policy {
      * Do not include the app secret in client-side code.
      */
     public Policy build(String appSecret) {
-      Gson gson = new Gson();
-      String jsonPolicy = gson.toJson(this);
+      String jsonPolicy = buildJsonPolicy();
       String encodedPolicy = Util.base64Url(jsonPolicy.getBytes());
       String signature = Hash.hmacSha256(
           appSecret.getBytes(Charset.forName("UTF-8")),
           encodedPolicy.getBytes(Charset.forName("UTF-8"))
       );
       return new Policy(encodedPolicy, signature);
+    }
+
+    private String buildJsonPolicy() {
+      JsonObject json = new JsonObject();
+      Util.addIfNotNull(json, "expiry", expiry);
+      if (calls != null) {
+        JsonArray callsArray = new JsonArray();
+        for (String call : calls) {
+          callsArray.add(call);
+        }
+        json.add("calls", callsArray);
+      }
+      Util.addIfNotNull(json, "handle", handle);
+      Util.addIfNotNull(json, "url", url);
+      Util.addIfNotNull(json, "maxSize", maxSize);
+      Util.addIfNotNull(json, "minSize", minSize);
+      Util.addIfNotNull(json, "path", path);
+      Util.addIfNotNull(json, "container", container);
+      return json.toString();
     }
   }
 

--- a/src/main/java/com/filestack/internal/Util.java
+++ b/src/main/java/com/filestack/internal/Util.java
@@ -1,6 +1,8 @@
 package com.filestack.internal;
 
 import com.filestack.HttpException;
+import com.google.gson.JsonObject;
+import io.reactivex.annotations.Nullable;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -8,7 +10,6 @@ import okio.Buffer;
 import okio.ByteString;
 import retrofit2.Response;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -164,5 +165,24 @@ public class Util {
   public static String base64Url(byte[] data) {
     return ByteString.of(data).base64Url();
   }
+
+  /**
+   * Populates {@link JsonObject} if value is not null.
+   */
+  public static void addIfNotNull(JsonObject object, String key, String value) {
+    if (value != null) {
+      object.addProperty(key, value);
+    }
+  }
+
+  /**
+   * Populates {@link JsonObject} if value is not null.
+   */
+  public static void addIfNotNull(JsonObject object, String key, Number value) {
+    if (value != null) {
+      object.addProperty(key, value);
+    }
+  }
+
 
 }

--- a/src/main/resources/META-INF/proguard/filestack.pro
+++ b/src/main/resources/META-INF/proguard/filestack.pro
@@ -19,9 +19,6 @@
     <init>(...);
 }
 
--keep public class com.filestack.Policy { *; }
--keep public class com.filestack.Policy$Builder { *; }
-
 # OkHttp-specific rules
 -dontwarn javax.annotation.**
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase

--- a/src/test/java/com/filestack/TestPolicy.java
+++ b/src/test/java/com/filestack/TestPolicy.java
@@ -1,6 +1,5 @@
 package com.filestack;
 
-import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,8 +25,6 @@ public class TestPolicy {
 
   @Test
   public void testNormal() {
-    Gson gson = new Gson();
-
     Policy policy = new Policy.Builder()
         .expiry(4653651600L)
         .calls(Policy.CALL_WRITE, Policy.CALL_REMOVE)
@@ -45,8 +42,6 @@ public class TestPolicy {
 
   @Test
   public void testNoCalls() {
-    Gson gson = new Gson();
-
     Policy policy = new Policy.Builder()
         .expiry(4653651600L)
         .build(TEST_SECRET);


### PR DESCRIPTION
-- this is to ensure that Gson doesn't leak implementation details of Policy.Builder class