### PR TITLE
Enable TLS 1.2 support for pre-KitKat Android devices

### DIFF
--- a/src/main/java/com/filestack/internal/Networking.java
+++ b/src/main/java/com/filestack/internal/Networking.java
@@ -1,8 +1,18 @@
 package com.filestack.internal;
 
 import com.google.gson.Gson;
+import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -11,26 +21,53 @@ import java.util.concurrent.TimeUnit;
  */
 public final class Networking {
 
-  private static OkHttpClient httpClient;
   private static BaseService baseService;
   private static CdnService cdnService;
   private static UploadService uploadService;
   private static CloudService cloudService;
 
-  private static final NetworkClient networkClient = new NetworkClient(getHttpClient(), new Gson());
+  private static final NetworkClient networkClient = new NetworkClient(buildOkHtttpClient(), new Gson());
 
   /** Get http fsClient singleton. */
-  public static OkHttpClient getHttpClient() {
-    if (httpClient == null) {
-      httpClient = new OkHttpClient.Builder()
-          .addInterceptor(new HeaderInterceptor())
-          .readTimeout(30, TimeUnit.SECONDS)
-          .connectTimeout(30, TimeUnit.SECONDS)
-          .writeTimeout(30, TimeUnit.SECONDS)
-          .retryOnConnectionFailure(false)
+  private static OkHttpClient buildOkHtttpClient() {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        .addInterceptor(new HeaderInterceptor())
+        .readTimeout(30, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(false);
+    setTls12Support(builder);
+    return builder.build();
+  }
+
+  private static void setTls12Support(OkHttpClient.Builder builder) {
+    try {
+      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+          TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init((KeyStore) null);
+      TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+      if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+        throw new IllegalStateException("Unexpected default trust managers:"
+            + Arrays.toString(trustManagers));
+      }
+
+      X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+      SSLContext sc = SSLContext.getInstance("TLSv1.2");
+      sc.init(null, null, null);
+      builder.sslSocketFactory(new TlsSocketFactory(sc.getSocketFactory()), trustManager);
+
+      ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+          .tlsVersions(TlsVersion.TLS_1_2)
           .build();
+
+      List<ConnectionSpec> specs = new ArrayList<>();
+      specs.add(cs);
+      specs.add(ConnectionSpec.COMPATIBLE_TLS);
+
+      builder.connectionSpecs(specs);
+    } catch (Exception exc) {
+      //fail silently for now
     }
-    return httpClient;
   }
 
   /**

--- a/src/main/java/com/filestack/internal/TlsSocketFactory.java
+++ b/src/main/java/com/filestack/internal/TlsSocketFactory.java
@@ -1,0 +1,60 @@
+package com.filestack.internal;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+class TlsSocketFactory extends SSLSocketFactory {
+
+  private static final String[] TLS_1_2 = {"TLSv1.2"};
+
+  private final SSLSocketFactory factory;
+
+  TlsSocketFactory(SSLSocketFactory factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return factory.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return factory.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+    return patch(factory.createSocket(socket, s, i, b));
+  }
+
+  @Override
+  public Socket createSocket(String s, int i) throws IOException {
+    return patch(factory.createSocket(s, i));
+  }
+
+  @Override
+  public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException {
+    return patch(factory.createSocket(s, i, inetAddress, i1));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+    return patch(factory.createSocket(inetAddress, i));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+    return patch(factory.createSocket(inetAddress, i, inetAddress1, i1));
+  }
+
+  private Socket patch(Socket s) {
+    if (s instanceof SSLSocket) {
+      ((SSLSocket) s).setEnabledProtocols(TLS_1_2);
+    }
+    return s;
+  }
+}


### PR DESCRIPTION
-- this change is required in order to make network requests work on pre Kitkat devices
-- take a look here: https://github.com/square/okhttp/issues/2372