### PR TITLE
Avoid relying on class loader to acquire library version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.2.70'
+    ext.kotlin_version = '1.2.71'
     repositories {
         mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.8'
+
     }
 }
 plugins {
@@ -16,6 +18,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 apply plugin: 'java-library'
+apply plugin: 'de.fuerstenau.buildconfig'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
@@ -39,6 +42,18 @@ dependencies {
 
 }
 
+// Add generated build-config directories to the main source set, so that the
+// IDE doesn't complain when the app references BuildConfig classes
+sourceSets.main.java {
+    srcDir new File(buildDir, 'gen/buildconfig')
+}
+
+buildConfig {
+    version = project.version // sets value of VERSION field,
+    clsName = 'FilestackBuildConfig'
+    packageName = project.group
+}
+
 javadoc {
     destinationDir new File("./docs")
     options.optionFiles(new File('./config/javadoc/javadoc.txt'))
@@ -59,16 +74,6 @@ repositories {
     jcenter()
 }
 
-// Output version to version.properties file
-task createProperties(dependsOn: processResources) {
-    doLast {
-        new File("$buildDir/resources/main/version.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
-    }
-}
 
 // Create javadoc artifact jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -81,8 +86,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource
 }
-
-classes.dependsOn createProperties // Create version.properties as part of build
 
 tasks.withType(Test) { // Put unit and integration test reports in separate directories
     reports.html.destination = file("${reporting.baseDir}/${name}")

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,7 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
+    <suppress files=".*FilestackBuildConfig" checks=".*"/>
     <suppress files="com[\\/]filestack[\\/]internal[\\/]" checks="JavadocMethod"/>
     <suppress files=".*[\\/]src[\\/](test)[\\/]" checks="AvoidStarImport|OperatorWrap"/>
 </suppressions>

--- a/src/main/java/com/filestack/internal/HeaderInterceptor.java
+++ b/src/main/java/com/filestack/internal/HeaderInterceptor.java
@@ -1,34 +1,31 @@
 package com.filestack.internal;
 
-import java.io.IOException;
-
+import com.filestack.FilestackBuildConfig;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Locale;
 
 /**
  * Intercepts requests to add Filestack headers.
  */
 public class HeaderInterceptor implements Interceptor {
-  public static String HEADER_USER_AGENT = "User-Agent";
-  public static String HEADER_FILESTACK_SOURCE = "Filestack-Source";
+  static String HEADER_USER_AGENT = "User-Agent";
+  static String HEADER_FILESTACK_SOURCE = "Filestack-Source";
 
-  public static String USER_AGENT = "filestack-java %s";
-  public static String FILESTACK_SOURCE = "Java-%s";
-
-  private String version;
-
-  HeaderInterceptor() {
-    this.version = Util.getVersion();
-  }
+  static String VERSION = FilestackBuildConfig.VERSION;
+  static String USER_AGENT = String.format(Locale.ROOT, "filestack-java %s", VERSION);
+  static String FILESTACK_SOURCE = String.format(Locale.ROOT, "Java-%s", VERSION);
 
   @Override
   public Response intercept(Chain chain) throws IOException {
     Request original = chain.request();
 
     Request modified = original.newBuilder()
-        .addHeader(HEADER_USER_AGENT, String.format(USER_AGENT, version))
-        .addHeader(HEADER_FILESTACK_SOURCE, String.format(FILESTACK_SOURCE, version))
+        .addHeader(HEADER_USER_AGENT, USER_AGENT)
+        .addHeader(HEADER_FILESTACK_SOURCE, FILESTACK_SOURCE)
         .build();
 
     return chain.proceed(modified);

--- a/src/main/java/com/filestack/internal/Util.java
+++ b/src/main/java/com/filestack/internal/Util.java
@@ -12,34 +12,11 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 /**
  * Small helper functions that don't need their own class.
  */
 public class Util {
-
-  /**
-   * Loads version string from properties file in resources folder.
-   *
-   * @return Version string
-   */
-  public static String getVersion() {
-    ClassLoader loader = Thread.currentThread().getContextClassLoader();
-    InputStream inputStream = loader.getResourceAsStream("com/filestack/version.properties");
-    Properties prop = new Properties();
-    String version;
-
-    try {
-      prop.load(inputStream);
-      version = prop.getProperty("version");
-    } catch (IOException e) {
-      version = "x.y.z";
-    }
-
-    return version;
-  }
 
   /**
    * Creates {@link RequestBody Request Body} from String.

--- a/src/test/java/com/filestack/internal/TestHeaderInterceptor.java
+++ b/src/test/java/com/filestack/internal/TestHeaderInterceptor.java
@@ -1,16 +1,12 @@
 package com.filestack.internal;
 
+import okhttp3.*;
+import okhttp3.Response;
+import org.junit.Test;
+
 import java.io.IOException;
 
-import okhttp3.Interceptor;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests {@link HeaderInterceptor} class to check if headers are added.
@@ -40,18 +36,10 @@ public class TestHeaderInterceptor {
     Response response = client.newCall(original).execute();
     Request modified = response.request();
 
-    String version = Util.getVersion();
-
     String headerUserAgent = modified.header(HeaderInterceptor.HEADER_USER_AGENT);
     String headerFilestackSource = modified.header(HeaderInterceptor.HEADER_FILESTACK_SOURCE);
 
-    Assert.assertNotNull(headerUserAgent);
-    Assert.assertNotNull(headerFilestackSource);
-
-    String correctUserAgent = String.format(HeaderInterceptor.USER_AGENT, version);
-    String correctFilestackSource = String.format(HeaderInterceptor.FILESTACK_SOURCE, version);
-
-    Assert.assertEquals(correctUserAgent, headerUserAgent);
-    Assert.assertEquals(correctFilestackSource, headerFilestackSource);
+    assertEquals(HeaderInterceptor.USER_AGENT, headerUserAgent);
+    assertEquals(HeaderInterceptor.FILESTACK_SOURCE, headerFilestackSource);
   }
 }


### PR DESCRIPTION
Resolves one of the issues in https://github.com/filestack/filestack-java/issues/80